### PR TITLE
Fix gestion background

### DIFF
--- a/app/helpers/servers_helper.rb
+++ b/app/helpers/servers_helper.rb
@@ -206,9 +206,9 @@ module ServersHelper # rubocop:disable Metrics/ModuleLength
   end
 
   def define_background_color(server:, mode: nil)
-    if %w(gestionnaire cluster).include?(mode)
+    if %w(gestion cluster).include?(mode)
       case mode
-      when 'gestionnaire'
+      when 'gestion'
         parent_type = 'Gestionnaire'
         parent_id = server.gestion.try(:name)
       when 'cluster'

--- a/app/models/frame.rb
+++ b/app/models/frame.rb
@@ -67,7 +67,7 @@ class Frame < ApplicationRecord
       txt << "---------------\r\n"
       self.servers.each do |server|
         case detail
-        when 'gestionnaire'
+        when 'gestion'
           addition = server.gestion.try(:name)
         when 'cluster'
           addition = server.cluster.try(:name)

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -57,7 +57,7 @@
               <li><%= link_to Gestion.model_name.human,
                               url_for(params.except(:controller, :action)
                                             .permit(:view, :islet, :id, :bg, :format)
-                                            .merge({ view: "front", bg: "gestionnaire", islet: params[:islet], id: params[:id] })),
+                                            .merge({ view: "front", bg: "gestion", islet: params[:islet], id: params[:id] })),
                               class: "dropdown-item" %></li>
               <li><%= link_to Cluster.model_name.human,
                               url_for(params.except(:controller, :action)


### PR DESCRIPTION
This PR fixes an error occuring when the user selects the "Gestionnaire" background color in a room overview.  