### PR TITLE
Fixing empty value too small on FF (Tom-select inputs)

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -800,6 +800,11 @@ body {
     }
   }
 
+  /* Tom-select fix for empty value on FF */
+  .ts-dropdown [data-selectable].option:empty:before {
+    content: "\200b";
+  }
+
   /* Visualization Infrastructure view */
   #network-capacity {
     .tab-content.infrastructure {


### PR DESCRIPTION
> Comme illustré dans la capture d'écran, sous Firefox uniquement, il est difficile de sélectionner une valeur vide dans les filtres car l'option a une hauteur beaucoup plus petite que les autres :

![image](https://github.com/user-attachments/assets/46d98824-4b99-48ab-9fb1-f816f4759248)
