### PR TITLE
358557 - Fix document deleted on server

### DIFF
--- a/app/javascript/controllers/nested_form_controller.js
+++ b/app/javascript/controllers/nested_form_controller.js
@@ -21,6 +21,7 @@ export default class extends Controller {
     if (wrapper.dataset.newRecord === "true") {
       wrapper.remove()
     } else {
+      wrapper.classList.remove("d-flex") // This adds a display: flex style that overrides the next display: none
       wrapper.style.display = "none"
       wrapper.querySelector("input[name*='_destroy']").value="1"
     }

--- a/app/javascript/controllers/nested_form_controller.js
+++ b/app/javascript/controllers/nested_form_controller.js
@@ -21,8 +21,7 @@ export default class extends Controller {
     if (wrapper.dataset.newRecord === "true") {
       wrapper.remove()
     } else {
-      wrapper.classList.remove("d-flex") // This adds a display: flex style that overrides the next display: none
-      wrapper.style.display = "none"
+      wrapper.classList.add("d-none")
       wrapper.querySelector("input[name*='_destroy']").value="1"
     }
   }


### PR DESCRIPTION
The document was still showing up on the Server form after being deleted.  

The issue comes from the `d-flex` class on the wrapper which hides our `display: none;`.