### PR TITLE
362827 - Add new blocks to show pages

### DIFF
--- a/app/views/air_conditioners/_form.html.erb
+++ b/app/views/air_conditioners/_form.html.erb
@@ -3,12 +3,22 @@
   <%= render FormErrorsComponent.new(@air_conditioner) %>
 
   <%= render CardComponent.new(extra_classes: "bg-body-tertiary") do |card| %>
+    <% card.with_header do %>
+      <%= t("show.cards.identification") %>
+    <% end %>
+
     <fieldset class="col-12">
       <%= f.label :name, class: "form-label" %>
       <%= f.text_field :name, class: "form-control" %>
     </fieldset>
+  <% end %>
 
-    <fieldset class="col-12 mt-4">
+  <%= render CardComponent.new(extra_classes: "bg-body-tertiary mt-4") do |card| %>
+    <% card.with_header do %>
+      <%= t("show.cards.features") %>
+    <% end %>
+
+    <fieldset class="col-12">
       <%= f.label :air_conditioner_model_id, class: "form-label" %>
       <%= f.select :air_conditioner_model_id,
                     options_from_collection_for_select(AirConditionerModel.all, :id, :name, @air_conditioner.air_conditioner_model_id),
@@ -114,7 +124,7 @@
       </div>
     </fieldset>
 
-    <div class="alert alert-info mt-4" role="alert">
+    <div class="alert alert-info mt-4 mb-0" role="alert">
       <%= simple_format t('.info-temperatures') %>
     </div>
   <% end %>

--- a/app/views/air_conditioners/show.html.erb
+++ b/app/views/air_conditioners/show.html.erb
@@ -11,12 +11,24 @@
   <div class="row row-cols-1 row-cols-lg-2 row-gap-4">
     <div class="col">
       <%= render CardComponent.new do |card| %>
+        <% card.with_header do %>
+          <%= t("show.cards.identification") %>
+        <% end %>
+
         <dl class="show-page_dl d-grid row-gap-2 mb-0">
           <% %i[name].each do |attribute_name| %>
             <dt class="pb-2"><%= AirConditioner.human_attribute_name(attribute_name) %></dt>
             <dd class="mb-0 pb-2 ps-3"><%= @air_conditioner.public_send(attribute_name) %></dd>
           <% end %>
+        </dl>
+      <% end %>
 
+      <%= render CardComponent.new(extra_classes: "mt-4") do |card| %>
+        <% card.with_header do %>
+          <%= t("show.cards.features") %>
+        <% end %>
+
+        <dl class="show-page_dl d-grid row-gap-2 mb-0">
           <dt class="pb-2"><%= AirConditioner.human_attribute_name(:air_conditioner_model_id) %></dt>
           <dd class="mb-0 pb-2 ps-3"><%= @air_conditioner.air_conditioner_model %></dd>
 
@@ -34,20 +46,6 @@
           <dd class="mb-0 pb-2 ps-3">
             <span><%= t("boolean.#{@air_conditioner.lift_pump}") %></span>
           </dd>
-        </dl>
-      <% end %>
-
-       <!-- Card shown on lg, in 2nd position (Grid isn't working as Masonry) -->
-      <%= render CardComponent.new(extra_classes: "d-none d-lg-flex mt-4") do |card| %>
-        <% card.with_header do %>
-          <%= t("air_conditioners.temperatures") %>
-        <% end %>
-
-        <dl class="show-page_dl d-grid row-gap-2 mb-0">
-          <% %i[setpoint start range].each do |attribute_name| %>
-            <dt class="pb-2"><%= AirConditioner.human_attribute_name(attribute_name) %></dt>
-            <dd class="mb-0 pb-2 ps-3"><%= "#{@air_conditioner.public_send(attribute_name)}°C" %></dd>
-          <% end %>
         </dl>
       <% end %>
     </div>
@@ -102,11 +100,8 @@
           <dd class="mb-0 pb-2 ps-3"><%= t("air_conditioners.form.#{@air_conditioner.position}") %></dd>
         </dl>
       <% end %>
-    </div>
 
-    <!-- Card shown on mobile, in 3rd position (Grid isn't working as Masonry) -->
-    <div class="col d-lg-none">
-      <%= render CardComponent.new(extra_classes: "d-lg-none") do |card| %>
+      <%= render CardComponent.new(extra_classes: "mt-4") do |card| %>
         <% card.with_header do %>
           <%= t("air_conditioners.temperatures") %>
         <% end %>

--- a/app/views/architectures/_form.html.erb
+++ b/app/views/architectures/_form.html.erb
@@ -1,6 +1,10 @@
 <%= form_for(@architecture, html: { class: "col-12 col-md-10 col-lg-8 mx-auto", role: "form" }) do |f| %>
   <%= render FormErrorsComponent.new(@architecture) %>
   <%= render CardComponent.new(extra_classes: "bg-body-tertiary") do |card| %>
+    <% card.with_header do %>
+      <%= t("show.cards.identification") %>
+    <% end %>
+
     <fieldset class="col-12">
       <%= f.label :name, class: "form-label" %>
       <%= f.text_field :name, class: "form-control" %>

--- a/app/views/architectures/show.html.erb
+++ b/app/views/architectures/show.html.erb
@@ -8,15 +8,21 @@
 
 <%= render Page::HeadingShowComponent.new(resource: @architecture, title: @architecture, breadcrumb_steps:) %>
 <div class="col-12 p-4 border-top">
-  <div class="col-12 col-lg-6">
-    <%= render CardComponent.new do |card| %>
-      <dl class="show-page_dl d-grid row-gap-2 mb-0">
-        <% %i[name description].each do |attribute_name| %>
-          <dt class="pb-2"><%= Architecture.human_attribute_name(attribute_name) %></dt>
-          <dd class="mb-0 pb-2 ps-3"><%= @architecture.public_send(attribute_name) %></dd>
+  <div class="row row-cols-1 row-cols-lg-2 row-gap-4">
+    <div class="col">
+      <%= render CardComponent.new do |card| %>
+        <% card.with_header do %>
+          <%= t("show.cards.identification") %>
         <% end %>
-      </dl>
-    <% end %>
+
+        <dl class="show-page_dl d-grid row-gap-2 mb-0">
+          <% %i[name description].each do |attribute_name| %>
+            <dt class="pb-2"><%= Architecture.human_attribute_name(attribute_name) %></dt>
+            <dd class="mb-0 pb-2 ps-3"><%= @architecture.public_send(attribute_name) %></dd>
+          <% end %>
+        </dl>
+      <% end %>
+    </div>
   </div>
   <%= render HasManyTurboFrameComponent.new(
     Modele.model_name.human.pluralize,

--- a/app/views/bays/_form.html.erb
+++ b/app/views/bays/_form.html.erb
@@ -1,6 +1,10 @@
 <%= form_for(@bay, html: { class: "col-12 col-md-10 col-lg-8 mx-auto", role: "form" }) do |f| %>
   <%= render FormErrorsComponent.new(@bay) %>
   <%= render CardComponent.new(extra_classes: "bg-body-tertiary") do |card| %>
+    <% card.with_header do %>
+      <%= t("show.cards.features") %>
+    <% end %>
+
     <div class="row g-3">
       <fieldset class="col-12">
         <%= f.label :bay_type_id, class: "form-label" %>

--- a/app/views/bays/show.html.erb
+++ b/app/views/bays/show.html.erb
@@ -21,6 +21,21 @@
   <div class="row row-cols-1 row-cols-lg-2 row-gap-4">
     <div class="col">
       <%= render CardComponent.new do |card| %>
+        <% card.with_header do %>
+          <%= t("show.cards.identification") %>
+        <% end %>
+
+        <dl class="show-page_dl d-grid row-gap-2 mb-0">
+          <dt class="pb-2"><%= Bay.human_attribute_name(:name) %></dt>
+          <dd class="mb-0 pb-2 ps-3"><%= @bay.to_s %></dd>
+        </dl>
+      <% end %>
+
+      <%= render CardComponent.new(extra_classes: "mt-4") do |card| %>
+        <% card.with_header do %>
+          <%= t("show.cards.features") %>
+        <% end %>
+
         <dl class="show-page_dl d-grid row-gap-2 mb-0">
           <dt class="pb-2"><%= Bay.human_attribute_name(:bay_type_id) %></dt>
           <dd class="mb-0 pb-2 ps-3"><%= @bay.bay_type %></dd>

--- a/app/views/card_types/_form.html.erb
+++ b/app/views/card_types/_form.html.erb
@@ -1,11 +1,22 @@
 <%= form_for(@card_type, html: { class: "col-12 col-md-10 col-lg-8 mx-auto", role: "form" }) do |f| %>
   <%= render FormErrorsComponent.new(@card_type) %>
   <%= render CardComponent.new(extra_classes: "bg-body-tertiary") do |card| %>
+    <% card.with_header do %>
+      <%= t("show.cards.identification") %>
+    <% end %>
+
     <fieldset class="col-12">
       <%= f.label :name, class: "form-label" %>
       <%= f.text_field :name, class: "form-control" %>
     </fieldset>
-    <fieldset class="col-12 mt-4">
+  <% end %>
+
+  <%= render CardComponent.new(extra_classes: "bg-body-tertiary mt-4") do |card| %>
+    <% card.with_header do %>
+      <%= t("show.cards.features") %>
+    <% end %>
+
+    <fieldset class="col-12">
       <%= f.label :port_type, class: "form-label" %>
       <%= f.select :port_type_id,
                    PortType.sorted.map { |pt| [pt.name, pt.id] },
@@ -17,22 +28,27 @@
                    }
       %>
     </fieldset>
+
     <fieldset class="col-12 mt-4">
       <%= f.label :port_quantity, class: "form-label" %>
       <%= f.number_field :port_quantity, class: "form-control" %>
     </fieldset>
+
     <fieldset class="col-12 mt-4">
       <%= f.label :columns, class: "form-label" %>
       <%= f.number_field :columns, class: "form-control" %>
     </fieldset>
+
     <fieldset class="col-12 mt-4">
       <%= f.label :rows, class: "form-label" %>
       <%= f.number_field :rows, class: "form-control" %>
     </fieldset>
+
     <fieldset class="col-12 mt-4">
       <%= f.label :max_aligned_ports, class: "form-label" %>
       <%= f.number_field :max_aligned_ports, class: "form-control" %>
     </fieldset>
+
     <fieldset class="col-12 mt-4">
       <%= f.label :first_position, class: "form-label" %>
       <%= f.select :first_position, [0, 1], {}, class: "form-select" %>

--- a/app/views/card_types/show.html.erb
+++ b/app/views/card_types/show.html.erb
@@ -8,15 +8,36 @@
 
 <%= render Page::HeadingShowComponent.new(resource: @card_type, title: @card_type.to_s, breadcrumb_steps:) %>
 <div class="col-12 p-4 border-top">
-  <div class="col-12 col-lg-6">
-    <%= render CardComponent.new do |card| %>
-      <dl class="show-page_dl d-grid row-gap-2 mb-0">
-        <% %i[name port_type port_quantity columns rows max_aligned_ports first_position].each do |attribute_name| %>
-          <dt class="pb-2"><%= CardType.human_attribute_name(attribute_name) %></dt>
-          <dd class="mb-0 pb-2 ps-3"><%= @card_type.public_send(attribute_name) %></dd>
+  <div class="row row-cols-1 row-cols-lg-2 row-gap-4">
+    <div class="col">
+      <%= render CardComponent.new do |card| %>
+        <% card.with_header do %>
+          <%= t("show.cards.identification") %>
         <% end %>
-      </dl>
-    <% end %>
+
+        <dl class="show-page_dl d-grid row-gap-2 mb-0">
+          <% %i[name].each do |attribute_name| %>
+            <dt class="pb-2"><%= CardType.human_attribute_name(attribute_name) %></dt>
+            <dd class="mb-0 pb-2 ps-3"><%= @card_type.public_send(attribute_name) %></dd>
+          <% end %>
+        </dl>
+      <% end %>
+    </div>
+
+    <div class="col">
+      <%= render CardComponent.new do |card| %>
+        <% card.with_header do %>
+          <%= t("show.cards.features") %>
+        <% end %>
+
+        <dl class="show-page_dl d-grid row-gap-2 mb-0">
+          <% %i[port_type port_quantity columns rows max_aligned_ports first_position].each do |attribute_name| %>
+            <dt class="pb-2"><%= CardType.human_attribute_name(attribute_name) %></dt>
+            <dd class="mb-0 pb-2 ps-3"><%= @card_type.public_send(attribute_name) %></dd>
+          <% end %>
+        </dl>
+      <% end %>
+    </div>
   </div>
   <%= render ChangelogEntries::ObjectListComponent.new(@card_type) %>
 </div>

--- a/app/views/categories/_form.html.erb
+++ b/app/views/categories/_form.html.erb
@@ -1,6 +1,10 @@
 <%= form_for(@category, html: { class: "col-12 col-md-10 col-lg-8 mx-auto", role: "form" }) do |f| %>
   <%= render FormErrorsComponent.new(@category) %>
   <%= render CardComponent.new(extra_classes: "bg-body-tertiary") do |card| %>
+    <% card.with_header do %>
+      <%= t("show.cards.identification") %>
+    <% end %>
+
     <fieldset class="col-12">
       <%= f.label :name, class: "form-label" %>
       <%= f.text_field :name, class: "form-control" %>
@@ -10,8 +14,14 @@
       <%= f.label :description, class: "forml-label" %>
       <%= f.text_area :description, class: "form-control" %>
     </fieldset>
+  <% end %>
 
-    <fieldset class="col-12 mt-4 form-check">
+  <%= render CardComponent.new(extra_classes: "bg-body-tertiary mt-4") do |card| %>
+    <% card.with_header do %>
+      <%= t("show.cards.features") %>
+    <% end %>
+
+    <fieldset class="col-12 form-check">
       <%= f.check_box :is_glpi_synchronizable, class: "form-check-input" %>
       <%= f.label :is_glpi_synchronizable, class: "form-check-label" %>
     </fieldset>

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -8,17 +8,34 @@
 
 <%= render Page::HeadingShowComponent.new(resource: @category, title: @category, breadcrumb_steps:) %>
 <div class="col-12 p-4 border-top">
-  <div class="col-12 col-lg-6">
-    <%= render CardComponent.new do |card| %>
-      <dl class="show-page_dl d-grid row-gap-2 mb-0">
-        <% %i[name description].each do |attribute_name| %>
-          <dt class="pb-2"><%= Category.human_attribute_name(attribute_name) %></dt>
-          <dd class="mb-0 pb-2 ps-3"><%= @category.public_send(attribute_name) %></dd>
+  <div class="row row-cols-1 row-cols-lg-2 row-gap-4">
+    <div class="col">
+      <%= render CardComponent.new do |card| %>
+        <% card.with_header do %>
+          <%= t("show.cards.identification") %>
         <% end %>
-        <dt class="pb-2"><%= Category.human_attribute_name(:is_glpi_synchronizable) %></dt>
-        <dd class="mb-0 pb-2 ps-3"><%= t("boolean.#{@category.is_glpi_synchronizable}") %></dd>
-      </dl>
-    <% end %>
+
+        <dl class="show-page_dl d-grid row-gap-2 mb-0">
+          <% %i[name description].each do |attribute_name| %>
+            <dt class="pb-2"><%= Category.human_attribute_name(attribute_name) %></dt>
+            <dd class="mb-0 pb-2 ps-3"><%= @category.public_send(attribute_name) %></dd>
+          <% end %>
+        </dl>
+      <% end %>
+    </div>
+
+    <div class="col">
+      <%= render CardComponent.new do |card| %>
+        <% card.with_header do %>
+          <%= t("show.cards.features") %>
+        <% end %>
+
+        <dl class="show-page_dl d-grid row-gap-2 mb-0">
+          <dt class="pb-2"><%= Category.human_attribute_name(:is_glpi_synchronizable) %></dt>
+          <dd class="mb-0 pb-2 ps-3"><%= t("boolean.#{@category.is_glpi_synchronizable}") %></dd>
+        </dl>
+      <% end %>
+    </div>
   </div>
   <%= render HasManyTurboFrameComponent.new(
     Modele.model_name.human.pluralize, url: modeles_path(category_ids: @category.id), frame_id: dom_id(Modele, :table)

--- a/app/views/clusters/_form.html.erb
+++ b/app/views/clusters/_form.html.erb
@@ -1,6 +1,10 @@
 <%= form_for(@cluster, html: { class: "col-12 col-md-10 col-lg-8 mx-auto", role: "form" }) do |f| %>
   <%= render FormErrorsComponent.new(@cluster) %>
   <%= render CardComponent.new(extra_classes: "bg-body-tertiary") do |card| %>
+    <% card.with_header do %>
+      <%= t("show.cards.identification") %>
+    <% end %>
+
     <fieldset class="col-12">
       <%= f.label :name, class: "form-label" %>
       <%= f.text_field :name, class: "form-control" %>

--- a/app/views/clusters/show.html.erb
+++ b/app/views/clusters/show.html.erb
@@ -8,15 +8,21 @@
 
 <%= render Page::HeadingShowComponent.new(resource: @cluster, title: @cluster.name, breadcrumb_steps:) %>
 <div class="col-12 p-4 border-top">
-  <div class="col-12 col-lg-6">
-    <%= render CardComponent.new do |card| %>
-      <dl class="show-page_dl d-grid row-gap-2 mb-0">
-        <% %i[name].each do |attribute_name| %>
-          <dt class="pb-2"><%= Cluster.human_attribute_name(attribute_name) %></dt>
-          <dd class="mb-0 pb-2 ps-3"><%= @cluster.public_send(attribute_name) %></dd>
+  <div class="row row-cols-1 row-cols-lg-2 row-gap-4">
+    <div class="col">
+      <%= render CardComponent.new do |card| %>
+        <% card.with_header do %>
+          <%= t("show.cards.identification") %>
         <% end %>
-      </dl>
-    <% end %>
+
+        <dl class="show-page_dl d-grid row-gap-2 mb-0">
+          <% %i[name].each do |attribute_name| %>
+            <dt class="pb-2"><%= Cluster.human_attribute_name(attribute_name) %></dt>
+            <dd class="mb-0 pb-2 ps-3"><%= @cluster.public_send(attribute_name) %></dd>
+          <% end %>
+        </dl>
+      <% end %>
+    </div>
   </div>
   <%= render HasManyTurboFrameComponent.new(
     Server.model_name.human.pluralize,

--- a/app/views/colors/_form.html.erb
+++ b/app/views/colors/_form.html.erb
@@ -1,6 +1,18 @@
 <%= form_for(@color, html: { class: "col-12 col-md-10 col-lg-8 mx-auto", role: "form" }) do |f| %>
   <%= render FormErrorsComponent.new(@color) %>
+
   <%= render CardComponent.new(extra_classes: "bg-body-tertiary") do |card| %>
+    <% card.with_header do %>
+      <%= t("show.cards.identification") %>
+    <% end %>
+
+    <fieldset class="col-12">
+      <%= f.label :code, class: "forml-label" %>
+      <%= f.text_field :code, class: "form-control" %>
+    </fieldset>
+  <% end %>
+
+  <%= render CardComponent.new(extra_classes: "bg-body-tertiary mt-4") do |card| %>
     <% card.with_header do %>
       <%= t("show.cards.features") %>
     <% end %>
@@ -13,11 +25,6 @@
     <fieldset class="col-12 mt-4">
       <%= f.label :parent_id, class: "forml-label" %>
       <%= f.text_field :parent_id, class: "form-control" %>
-    </fieldset>
-
-    <fieldset class="col-12 mt-4">
-      <%= f.label :code, class: "forml-label" %>
-      <%= f.text_field :code, class: "form-control" %>
     </fieldset>
   <% end %>
 

--- a/app/views/colors/_form.html.erb
+++ b/app/views/colors/_form.html.erb
@@ -1,6 +1,10 @@
 <%= form_for(@color, html: { class: "col-12 col-md-10 col-lg-8 mx-auto", role: "form" }) do |f| %>
   <%= render FormErrorsComponent.new(@color) %>
   <%= render CardComponent.new(extra_classes: "bg-body-tertiary") do |card| %>
+    <% card.with_header do %>
+      <%= t("show.cards.features") %>
+    <% end %>
+
     <fieldset class="col-12">
       <%= f.label :parent_type, class: "form-label" %>
       <%= f.text_field :parent_type, class: "form-control" %>

--- a/app/views/colors/show.html.erb
+++ b/app/views/colors/show.html.erb
@@ -8,17 +8,23 @@
 
 <%= render Page::HeadingShowComponent.new(resource: @color, title: @color.code, breadcrumb_steps:) %>
 <div class="col-12 p-4 border-top">
-  <div class="col-12 col-lg-6">
-    <%= render CardComponent.new do |card| %>
-      <dl class="show-page_dl d-grid row-gap-2 mb-0">
-        <% %i[parent_type parent_id code].each do |attribute_name| %>
-          <dt class="pb-2"><%= Color.human_attribute_name(attribute_name) %></dt>
-          <dd class="mb-0 pb-2 ps-3"><%= @color.public_send(attribute_name) %></dd>
+  <div class="row row-cols-1 row-cols-lg-2 row-gap-4">
+    <div class="col">
+      <%= render CardComponent.new do |card| %>
+        <% card.with_header do %>
+          <%= t("show.cards.features") %>
         <% end %>
 
-        <input type="color" class="form-control form-control-color" id="" value="<%= @color.code %>" disabled>
-      </dl>
-    <% end %>
+        <dl class="show-page_dl d-grid row-gap-2 mb-0">
+          <% %i[parent_type parent_id code].each do |attribute_name| %>
+            <dt class="pb-2"><%= Color.human_attribute_name(attribute_name) %></dt>
+            <dd class="mb-0 pb-2 ps-3"><%= @color.public_send(attribute_name) %></dd>
+          <% end %>
+
+          <input type="color" class="form-control form-control-color" id="" value="<%= @color.code %>" disabled>
+        </dl>
+      <% end %>
+    </div>
   </div>
 
   <%= render ChangelogEntries::ObjectListComponent.new(@color) %>

--- a/app/views/colors/show.html.erb
+++ b/app/views/colors/show.html.erb
@@ -12,16 +12,30 @@
     <div class="col">
       <%= render CardComponent.new do |card| %>
         <% card.with_header do %>
-          <%= t("show.cards.features") %>
+          <%= t("show.cards.identification") %>
         <% end %>
 
         <dl class="show-page_dl d-grid row-gap-2 mb-0">
-          <% %i[parent_type parent_id code].each do |attribute_name| %>
+          <% %i[code].each do |attribute_name| %>
             <dt class="pb-2"><%= Color.human_attribute_name(attribute_name) %></dt>
             <dd class="mb-0 pb-2 ps-3"><%= @color.public_send(attribute_name) %></dd>
           <% end %>
 
           <input type="color" class="form-control form-control-color" id="" value="<%= @color.code %>" disabled>
+        </dl>
+      <% end %>
+    </div>
+    <div class="col">
+      <%= render CardComponent.new do |card| %>
+        <% card.with_header do %>
+          <%= t("show.cards.features") %>
+        <% end %>
+
+        <dl class="show-page_dl d-grid row-gap-2 mb-0">
+          <% %i[parent_type parent_id].each do |attribute_name| %>
+            <dt class="pb-2"><%= Color.human_attribute_name(attribute_name) %></dt>
+            <dd class="mb-0 pb-2 ps-3"><%= @color.public_send(attribute_name) %></dd>
+          <% end %>
         </dl>
       <% end %>
     </div>

--- a/app/views/contact_assignments/_form.html.erb
+++ b/app/views/contact_assignments/_form.html.erb
@@ -2,6 +2,10 @@
   <%= render FormErrorsComponent.new(@contact_assignment) %>
 
   <%= render CardComponent.new(extra_classes: "bg-body-tertiary mt-4") do |card| %>
+    <% card.with_header do %>
+      <%= t("show.cards.features") %>
+    <% end %>
+
     <fieldset class="col-12">
       <%= f.label :contact_id, class: "form-label" %>
       <%= f.select :contact_id, Contact.all.map{ |c| [c.to_s, c.id] }, { prompt: true }, class: "form-select" %>

--- a/app/views/contact_assignments/show.html.erb
+++ b/app/views/contact_assignments/show.html.erb
@@ -12,6 +12,10 @@
   <div class="row row-cols-1 row-cols-lg-2 row-gap-4">
     <div class="col">
       <%= render CardComponent.new do |card| %>
+        <% card.with_header do %>
+          <%= t("show.cards.features") %>
+        <% end %>
+
         <dl class="show-page_dl d-grid row-gap-2 mb-0">
           <dt class="pb-2"><%= ContactAssignment.human_attribute_name(:contact_id) %></dt>
           <dd class="mb-0 pb-2 ps-3"><%= link_to @contact_assignment.contact, contact_path(@contact_assignment.contact) %></dd>

--- a/app/views/contact_roles/_form.html.erb
+++ b/app/views/contact_roles/_form.html.erb
@@ -2,6 +2,10 @@
   <%= render FormErrorsComponent.new(@contact_role) %>
 
   <%= render CardComponent.new(extra_classes: "bg-body-tertiary") do |card| %>
+    <% card.with_header do %>
+      <%= t("show.cards.identification") %>
+    <% end %>
+
     <fieldset class="col-12">
       <%= f.label :name, class: "form-label" %>
       <%= f.text_field :name, class: "form-control" %>

--- a/app/views/contact_roles/show.html.erb
+++ b/app/views/contact_roles/show.html.erb
@@ -7,16 +7,22 @@
 %>
 
 <%= render Page::HeadingShowComponent.new(resource: @contact_role, title: @contact_role, breadcrumb_steps:) %>
+
 <div class="col-12 p-4 border-top">
-  <div class="col-12 col-lg-6">
-    <%= render CardComponent.new do |card| %>
-      <dl class="show-page_dl d-grid row-gap-2 mb-0">
-        <% %i[name description].each do |attribute_name| %>
-          <dt class="pb-2"><%= ContactRole.human_attribute_name(attribute_name) %></dt>
-          <dd class="mb-0 pb-2 ps-3"><%= @contact_role.public_send(attribute_name) %></dd>
+  <div class="row row-cols-1 row-cols-lg-2 row-gap-4">
+    <div class="col">
+      <%= render CardComponent.new do |card| %>
+        <% card.with_header do %>
+          <%= t("show.cards.identification") %>
         <% end %>
-      </dl>
-    <% end %>
+        <dl class="show-page_dl d-grid row-gap-2 mb-0">
+          <% %i[name description].each do |attribute_name| %>
+            <dt class="pb-2"><%= ContactRole.human_attribute_name(attribute_name) %></dt>
+            <dd class="mb-0 pb-2 ps-3"><%= @contact_role.public_send(attribute_name) %></dd>
+          <% end %>
+        </dl>
+      <% end %>
+    </div>
   </div>
 
   <%= render ChangelogEntries::ObjectListComponent.new(@contact_role) %>

--- a/app/views/contacts/_form.html.erb
+++ b/app/views/contacts/_form.html.erb
@@ -2,6 +2,10 @@
   <%= render FormErrorsComponent.new(@contact) %>
 
   <%= render CardComponent.new(extra_classes: "bg-body-tertiary") do |card| %>
+    <% card.with_header do %>
+      <%= t("show.cards.identification") %>
+    <% end %>
+
     <fieldset class="col-12">
       <%= f.label :first_name, class: "form-label" %>
       <%= f.text_field :first_name, class: "form-control" %>
@@ -11,8 +15,14 @@
       <%= f.label :last_name, class: "form-label" %>
       <%= f.text_field :last_name, class: "form-control" %>
     </fieldset>
+  <% end %>
 
-    <fieldset class="col-12 mt-4">
+  <%= render CardComponent.new(extra_classes: "bg-body-tertiary mt-4") do |card| %>
+    <% card.with_header do %>
+      <%= t("show.cards.features") %>
+    <% end %>
+
+    <fieldset class="col-12">
       <%= f.label :phone_number, class: "form-label" %>
       <%= f.phone_field :phone_number, class: "form-control" %>
     </fieldset>

--- a/app/views/contacts/show.html.erb
+++ b/app/views/contacts/show.html.erb
@@ -7,28 +7,47 @@
 %>
 
 <%= render Page::HeadingShowComponent.new(resource: @contact, title: @contact, breadcrumb_steps:) %>
+
 <div class="col-12 p-4 border-top">
   <div class="row row-cols-1 row-cols-lg-2 row-gap-4">
     <div class="col">
       <%= render CardComponent.new do |card| %>
+        <% card.with_header do %>
+          <%= t("show.cards.identification") %>
+        <% end %>
+
         <dl class="show-page_dl d-grid row-gap-2 mb-0">
-          <% %i[first_name last_name phone_number email organization].each do |attribute_name| %>
+          <% %i[first_name last_name].each do |attribute_name| %>
             <dt class="pb-2"><%= Contact.human_attribute_name(attribute_name) %></dt>
             <dd class="mb-0 pb-2 ps-3"><%= @contact.public_send(attribute_name) %></dd>
           <% end %>
         </dl>
       <% end %>
     </div>
+
     <div class="col">
-      <%= render HasManyTurboFrameComponent.new(
-          ContactAssignment.model_name.human.pluralize,
-          type: :warning,
-          url: contact_assignments_path(contact_ids: @contact.id),
-          frame_id: dom_id(ContactAssignment, :table),
-          extra_classes: "bg-body-tertiary"
-      ) %>
+      <%= render CardComponent.new do |card| %>
+        <% card.with_header do %>
+          <%= t("show.cards.features") %>
+        <% end %>
+
+        <dl class="show-page_dl d-grid row-gap-2 mb-0">
+          <% %i[phone_number email organization].each do |attribute_name| %>
+            <dt class="pb-2"><%= Contact.human_attribute_name(attribute_name) %></dt>
+            <dd class="mb-0 pb-2 ps-3"><%= @contact.public_send(attribute_name) %></dd>
+          <% end %>
+        </dl>
+      <% end %>
     </div>
   </div>
+
+  <%= render HasManyTurboFrameComponent.new(
+      ContactAssignment.model_name.human.pluralize,
+      type: :warning,
+      url: contact_assignments_path(contact_ids: @contact.id),
+      frame_id: dom_id(ContactAssignment, :table),
+      extra_classes: "bg-body-tertiary mt-4"
+  ) %>
 
   <%= render ChangelogEntries::ObjectListComponent.new(@contact) %>
 </div>

--- a/app/views/disk_types/_form.html.erb
+++ b/app/views/disk_types/_form.html.erb
@@ -1,6 +1,10 @@
 <%= form_for(@disk_type, html: { class: "col-12 col-md-10 col-lg-8 mx-auto", role: "form" }) do |f| %>
   <%= render FormErrorsComponent.new(@disk_type) %>
   <%= render CardComponent.new(extra_classes: "bg-body-tertiary") do |card| %>
+    <% card.with_header do %>
+      <%= t("show.cards.features") %>
+    <% end %>
+
     <fieldset class="col-12">
       <%= f.label :quantity, class: "form-label" %>
       <%= f.number_field :quantity, class: "form-control" %>

--- a/app/views/disk_types/show.html.erb
+++ b/app/views/disk_types/show.html.erb
@@ -8,15 +8,21 @@
 
 <%= render Page::HeadingShowComponent.new(resource: @disk_type, title: @disk_type.to_s, breadcrumb_steps:) %>
 <div class="col-12 p-4 border-top">
-  <div class="col-12 col-lg-6">
-    <%= render CardComponent.new do |card| %>
-      <dl class="show-page_dl d-grid row-gap-2 mb-0">
-        <% %i[quantity unit technology].each do |attribute_name| %>
-          <dt class="pb-2"><%= DiskType.human_attribute_name(attribute_name) %></dt>
-          <dd class="mb-0 pb-2 ps-3"><%= @disk_type.public_send(attribute_name) %></dd>
+  <div class="row row-cols-1 row-cols-lg-2 row-gap-4">
+    <div class="col">
+      <%= render CardComponent.new do |card| %>
+        <% card.with_header do %>
+          <%= t("show.cards.features") %>
         <% end %>
-      </dl>
-    <% end %>
+
+        <dl class="show-page_dl d-grid row-gap-2 mb-0">
+          <% %i[quantity unit technology].each do |attribute_name| %>
+            <dt class="pb-2"><%= DiskType.human_attribute_name(attribute_name) %></dt>
+            <dd class="mb-0 pb-2 ps-3"><%= @disk_type.public_send(attribute_name) %></dd>
+          <% end %>
+        </dl>
+      <% end %>
+    </div>
   </div>
   <%= render ChangelogEntries::ObjectListComponent.new(@disk_type) %>
 </div>

--- a/app/views/domaines/_form.html.erb
+++ b/app/views/domaines/_form.html.erb
@@ -1,6 +1,10 @@
 <%= form_for(@domaine, html: { class: "col-12 col-md-10 col-lg-8 mx-auto", role: "form" }) do |f| %>
   <%= render FormErrorsComponent.new(@domaine) %>
   <%= render CardComponent.new(extra_classes: "bg-body-tertiary") do |card| %>
+    <% card.with_header do %>
+      <%= t("show.cards.identification") %>
+    <% end %>
+
     <fieldset class="col-12">
       <%= f.label :name, class: "form-label" %>
       <%= f.text_field :name, class: "form-control" %>

--- a/app/views/domaines/show.html.erb
+++ b/app/views/domaines/show.html.erb
@@ -8,15 +8,21 @@
 
 <%= render Page::HeadingShowComponent.new(resource: @domaine, title: @domaine.name, breadcrumb_steps:) %>
 <div class="col-12 p-4 border-top">
-  <div class="col-12 col-lg-6">
-    <%= render CardComponent.new do |card| %>
-      <dl class="show-page_dl d-grid row-gap-2 mb-0">
-        <% %i[name description].each do |attribute_name| %>
-          <dt class="pb-2"><%= Domaine.human_attribute_name(attribute_name) %></dt>
-          <dd class="mb-0 pb-2 ps-3"><%= @domaine.public_send(attribute_name) %></dd>
+  <div class="row row-cols-1 row-cols-lg-2 row-gap-4">
+    <div class="col">
+      <%= render CardComponent.new do |card| %>
+        <% card.with_header do %>
+          <%= t("show.cards.identification") %>
         <% end %>
-      </dl>
-    <% end %>
+
+        <dl class="show-page_dl d-grid row-gap-2 mb-0">
+          <% %i[name description].each do |attribute_name| %>
+            <dt class="pb-2"><%= Domaine.human_attribute_name(attribute_name) %></dt>
+            <dd class="mb-0 pb-2 ps-3"><%= @domaine.public_send(attribute_name) %></dd>
+          <% end %>
+        </dl>
+      <% end %>
+    </div>
   </div>
   <%= render HasManyTurboFrameComponent.new(
     Server.model_name.human.pluralize,

--- a/app/views/frames/_form.html.erb
+++ b/app/views/frames/_form.html.erb
@@ -1,18 +1,30 @@
 <%= form_for(@frame, html: { class: "col-12 col-md-10 col-lg-8 mx-auto", role: "form" }) do |f| %>
   <%= render FormErrorsComponent.new(@frame) %>
   <%= render CardComponent.new(extra_classes: "bg-body-tertiary") do |card| %>
+    <% card.with_header do %>
+      <%= t("show.cards.identification") %>
+    <% end %>
+
     <div class="row g-3">
       <fieldset class="col-12">
         <%= f.label :name, class: "form-label" %>
         <%= f.text_field :name, class: "form-control" %>
       </fieldset>
+    </div>
+  <% end %>
 
-      <fieldset class="col-md-6 col-12 mt-4">
+  <%= render CardComponent.new(extra_classes: "bg-body-tertiary mt-4") do |card| %>
+    <% card.with_header do %>
+      <%= t("show.cards.features") %>
+    <% end %>
+
+    <div class="row g-3">
+      <fieldset class="col-md-6 col-12">
         <%= f.label :u, class: "form-label" %>
         <%= f.number_field :u, class: "form-control" %>
       </fieldset>
 
-      <fieldset class="col-md-6 col-12 mt-4">
+      <fieldset class="col-md-6 col-12">
         <%= f.label :width, class: "form-label" %>
           <div class="input-group">
             <%= f.number_field :width, step: :any, class: "form-control" %>

--- a/app/views/frames/show.html.erb
+++ b/app/views/frames/show.html.erb
@@ -19,11 +19,24 @@
   <div class="row row-cols-1 row-cols-lg-2 row-gap-4">
     <div class="col">
       <%= render CardComponent.new do |card| %>
+        <% card.with_header do %>
+          <%= t("show.cards.identification") %>
+        <% end %>
+
         <dl class="show-page_dl d-grid row-gap-2 mb-0">
-          <% %i[name u].each do |attribute_name| %>
-            <dt class="pb-2"><%= Frame.human_attribute_name(attribute_name) %></dt>
-            <dd class="mb-0 pb-2 ps-3"><%= @frame.public_send(attribute_name) %></dd>
-          <% end %>
+          <dt class="pb-2"><%= Frame.human_attribute_name(:name) %></dt>
+          <dd class="mb-0 pb-2 ps-3"><%= @frame.name %></dd
+        </dl>
+      <% end %>
+
+      <%= render CardComponent.new(extra_classes: "mt-4") do |card| %>
+        <% card.with_header do %>
+          <%= t("show.cards.features") %>
+        <% end %>
+
+        <dl class="show-page_dl d-grid row-gap-2 mb-0">
+          <dt class="pb-2"><%= Frame.human_attribute_name(:u) %></dt>
+          <dd class="mb-0 pb-2 ps-3"><%= @frame.u %></dd>
 
           <dt class="pb-2"><%= Frame.human_attribute_name(:width) %></dt>
           <dd class="mb-0 pb-2 ps-3"><%= value_with_unit(@frame.width, :inches) %></dd>

--- a/app/views/gestions/_form.html.erb
+++ b/app/views/gestions/_form.html.erb
@@ -1,6 +1,10 @@
 <%= form_for(@gestion, html: { class: "col-12 col-md-10 col-lg-8 mx-auto", role: "form" }) do |f| %>
   <%= render FormErrorsComponent.new(@gestion) %>
   <%= render CardComponent.new(extra_classes: "bg-body-tertiary") do |card| %>
+    <% card.with_header do %>
+      <%= t("show.cards.identification") %>
+    <% end %>
+
     <fieldset class="col-12">
       <%= f.label :name, class: "form-label" %>
       <%= f.text_field :name, class: "form-control" %>

--- a/app/views/gestions/show.html.erb
+++ b/app/views/gestions/show.html.erb
@@ -8,15 +8,21 @@
 
 <%= render Page::HeadingShowComponent.new(resource: @gestion, title: @gestion.name, breadcrumb_steps:) %>
 <div class="col-12 p-4 border-top">
-  <div class="col-12 col-lg-6">
-    <%= render CardComponent.new do |card| %>
-      <dl class="show-page_dl d-grid row-gap-2 mb-0">
-        <% %i[name description].each do |attribute_name| %>
-          <dt class="pb-2"><%= Gestion.human_attribute_name(attribute_name) %></dt>
-          <dd class="mb-0 pb-2 ps-3"><%= @gestion.public_send(attribute_name) %></dd>
+  <div class="row row-cols-1 row-cols-lg-2 row-gap-4">
+    <div class="col">
+      <%= render CardComponent.new do |card| %>
+        <% card.with_header do %>
+          <%= t("show.cards.identification") %>
         <% end %>
-      </dl>
-    <% end %>
+
+        <dl class="show-page_dl d-grid row-gap-2 mb-0">
+          <% %i[name description].each do |attribute_name| %>
+            <dt class="pb-2"><%= Gestion.human_attribute_name(attribute_name) %></dt>
+            <dd class="mb-0 pb-2 ps-3"><%= @gestion.public_send(attribute_name) %></dd>
+          <% end %>
+        </dl>
+      <% end %>
+    </div>
   </div>
   <%= render HasManyTurboFrameComponent.new(
     Server.model_name.human.pluralize,

--- a/app/views/islets/_form.html.erb
+++ b/app/views/islets/_form.html.erb
@@ -1,6 +1,10 @@
 <%= form_for(@islet, html: { class: "col-12 col-md-10 col-lg-8 mx-auto", role: "form" }) do |f| %>
   <%= render FormErrorsComponent.new(@islet) %>
   <%= render CardComponent.new(extra_classes: "bg-body-tertiary") do |card| %>
+    <% card.with_header do %>
+      <%= t("show.cards.identification") %>
+    <% end %>
+
     <fieldset class="col-12">
       <%= f.label :name, class: "form-label" %>
       <%= f.text_field :name, class: "form-control" %>
@@ -10,8 +14,14 @@
       <%= f.label :description, class: "form-label" %>
       <%= f.text_area :description, class: "form-control" %>
     </fieldset>
+  <% end %>
 
-    <fieldset class="col-12 mt-4">
+  <%= render CardComponent.new(extra_classes: "bg-body-tertiary mt-4") do |card| %>
+    <% card.with_header do %>
+      <%= t("show.cards.features") %>
+    <% end %>
+
+    <fieldset class="col-12">
       <%= f.label :cooling_mode, class: "form-label" %>
       <%= f.select :cooling_mode,
                    IsletDecorator.cooling_modes_options_for_select,

--- a/app/views/islets/show.html.erb
+++ b/app/views/islets/show.html.erb
@@ -11,12 +11,24 @@
   <div class="row row-cols-1 row-cols-lg-2 row-gap-4">
     <div class="col">
       <%= render CardComponent.new do |card| %>
+        <% card.with_header do %>
+          <%= t("show.cards.identification") %>
+        <% end %>
+
         <dl class="show-page_dl d-grid row-gap-2 mb-0">
           <% %i[name description].each do |attribute_name| %>
             <dt class="pb-2"><%= Islet.human_attribute_name(attribute_name) %></dt>
             <dd class="mb-0 pb-2 ps-3"><%= @islet.public_send(attribute_name) %></dd>
           <% end %>
+        </dl>
+      <% end %>
 
+      <%= render CardComponent.new(extra_classes: "mt-4") do |card| %>
+        <% card.with_header do %>
+          <%= t("show.cards.features") %>
+        <% end %>
+
+        <dl class="show-page_dl d-grid row-gap-2 mb-0">
           <dt class="pb-2"><%= Islet.human_attribute_name(:cooling_mode) %></dt>
           <dd class="mb-0 pb-2 ps-3"><%= @islet.decorated.cooling_mode_to_human %></dd>
 

--- a/app/views/manufacturers/_form.html.erb
+++ b/app/views/manufacturers/_form.html.erb
@@ -1,6 +1,10 @@
 <%= form_for(@manufacturer, html: { class: "col-12 col-md-10 col-lg-8 mx-auto", role: "form" }) do |f| %>
   <%= render FormErrorsComponent.new(@manufacturer) %>
   <%= render CardComponent.new(extra_classes: "bg-body-tertiary") do |card| %>
+    <% card.with_header do %>
+      <%= t("show.cards.identification") %>
+    <% end %>
+
     <fieldset class="col-12">
       <%= f.label :name, class: "form-label" %>
       <%= f.text_field :name, class: "form-control" %>
@@ -9,7 +13,14 @@
       <%= f.label :description, class: "form-label" %>
       <%= f.text_area :description, class: "form-control" %>
     </fieldset>
-    <fieldset class="col-12 mt-4">
+  <% end %>
+
+  <%= render CardComponent.new(extra_classes: "bg-body-tertiary mt-4") do |card| %>
+    <% card.with_header do %>
+      <%= t("show.cards.features") %>
+    <% end %>
+
+    <fieldset class="col-12">
       <%= f.label :documentation_url, class: "form-label" %>
       <%= f.text_field :documentation_url, placeholder: t(".url_placeholder"), class: "form-control" %>
       <span class="form-text">

--- a/app/views/manufacturers/show.html.erb
+++ b/app/views/manufacturers/show.html.erb
@@ -8,15 +8,35 @@
 
 <%= render Page::HeadingShowComponent.new(resource: @manufacturer, title: @manufacturer.name, breadcrumb_steps:) %>
 <div class="col-12 p-4 border-top">
-  <div class="col-12 col-lg-6">
-    <%= render CardComponent.new do |card| %>
-      <dl class="show-page_dl d-grid row-gap-2 mb-0">
-        <% %i[name description documentation_url].each do |attribute_name| %>
-          <dt class="pb-2"><%= Manufacturer.human_attribute_name(attribute_name) %></dt>
-          <dd class="mb-0 pb-2 ps-3"><%= @manufacturer.public_send(attribute_name) %></dd>
+  <div class="row row-cols-1 row-cols-lg-2 row-gap-4">
+    <div class="col">
+      <%= render CardComponent.new do |card| %>
+        <% card.with_header do %>
+          <%= t("show.cards.identification") %>
         <% end %>
-      </dl>
-    <% end %>
+
+        <dl class="show-page_dl d-grid row-gap-2 mb-0">
+          <% %i[name description].each do |attribute_name| %>
+            <dt class="pb-2"><%= Manufacturer.human_attribute_name(attribute_name) %></dt>
+            <dd class="mb-0 pb-2 ps-3"><%= @manufacturer.public_send(attribute_name) %></dd>
+          <% end %>
+        </dl>
+      <% end %>
+    </div>
+    <div class="col">
+      <%= render CardComponent.new do |card| %>
+        <% card.with_header do %>
+          <%= t("show.cards.features") %>
+        <% end %>
+
+        <dl class="show-page_dl d-grid row-gap-2 mb-0">
+          <% %i[documentation_url].each do |attribute_name| %>
+            <dt class="pb-2"><%= Manufacturer.human_attribute_name(attribute_name) %></dt>
+            <dd class="mb-0 pb-2 ps-3"><%= @manufacturer.public_send(attribute_name) %></dd>
+          <% end %>
+        </dl>
+      <% end %>
+    </div>
   </div>
   <%= render HasManyTurboFrameComponent.new(
     Modele.model_name.human.pluralize,

--- a/app/views/memory_types/_form.html.erb
+++ b/app/views/memory_types/_form.html.erb
@@ -1,6 +1,10 @@
 <%= form_for(@memory_type, html: { class: "col-12 col-md-10 col-lg-8 mx-auto", role: "form" }) do |f| %>
   <%= render FormErrorsComponent.new(@memory_type) %>
   <%= render CardComponent.new(extra_classes: "bg-body-tertiary") do |card| %>
+    <% card.with_header do %>
+      <%= t("show.cards.features") %>
+    <% end %>
+
     <fieldset class="col-12">
       <%= f.label :quantity, class: "form-label" %>
       <%= f.text_field :quantity, class: "form-control" %>

--- a/app/views/memory_types/_form.html.erb
+++ b/app/views/memory_types/_form.html.erb
@@ -2,7 +2,7 @@
   <%= render FormErrorsComponent.new(@memory_type) %>
   <%= render CardComponent.new(extra_classes: "bg-body-tertiary") do |card| %>
     <% card.with_header do %>
-      <%= t("show.cards.features") %>
+      <%= t("show.cards.identification") %>
     <% end %>
 
     <fieldset class="col-12">

--- a/app/views/memory_types/show.html.erb
+++ b/app/views/memory_types/show.html.erb
@@ -8,15 +8,21 @@
 
 <%= render Page::HeadingShowComponent.new(resource: @memory_type, title: @memory_type.to_s, breadcrumb_steps:) %>
 <div class="col-12 p-4 border-top">
-  <div class="col-12 col-lg-6">
-    <%= render CardComponent.new do |card| %>
-      <dl class="show-page_dl d-grid row-gap-2 mb-0">
-        <% %i[quantity unit].each do |attribute_name| %>
-          <dt class="pb-2"><%= MemoryType.human_attribute_name(attribute_name) %></dt>
-          <dd class="mb-0 pb-2 ps-3"><%= @memory_type.public_send(attribute_name) %></dd>
+  <div class="row row-cols-1 row-cols-lg-2 row-gap-4">
+    <div class="col">
+      <%= render CardComponent.new do |card| %>
+        <% card.with_header do %>
+          <%= t("show.cards.features") %>
         <% end %>
-      </dl>
-    <% end %>
+
+        <dl class="show-page_dl d-grid row-gap-2 mb-0">
+          <% %i[quantity unit].each do |attribute_name| %>
+            <dt class="pb-2"><%= MemoryType.human_attribute_name(attribute_name) %></dt>
+            <dd class="mb-0 pb-2 ps-3"><%= @memory_type.public_send(attribute_name) %></dd>
+          <% end %>
+        </dl>
+      <% end %>
+    </div>
   </div>
   <%= render ChangelogEntries::ObjectListComponent.new(@memory_type) %>
 </div>

--- a/app/views/memory_types/show.html.erb
+++ b/app/views/memory_types/show.html.erb
@@ -12,7 +12,7 @@
     <div class="col">
       <%= render CardComponent.new do |card| %>
         <% card.with_header do %>
-          <%= t("show.cards.features") %>
+          <%= t("show.cards.identification") %>
         <% end %>
 
         <dl class="show-page_dl d-grid row-gap-2 mb-0">

--- a/app/views/modeles/_form.html.erb
+++ b/app/views/modeles/_form.html.erb
@@ -1,12 +1,22 @@
 <%= form_for(@modele, html: { class: "col-12 col-md-10 col-lg-8 mx-auto", role: "form" }, data: { turbo: true }) do |f| %>
   <%= render FormErrorsComponent.new(@modele) %>
   <%= render CardComponent.new(extra_classes: "bg-body-tertiary") do |card| %>
+    <% card.with_header do %>
+      <%= t("show.cards.identification") %>
+    <% end %>
+
     <fieldset class="col-12">
       <%= f.label :name, class: "form-label" %>
       <%= f.text_field :name, class: "form-control" %>
     </fieldset>
+  <% end %>
 
-    <fieldset class="col-12 mt-4">
+  <%= render CardComponent.new(extra_classes: "bg-body-tertiary mt-4") do |card| %>
+    <% card.with_header do %>
+      <%= t("show.cards.features") %>
+    <% end %>
+
+    <fieldset class="col-12">
       <%= f.label :category_id, class: "form-label" %>
       <%= f.collection_select(:category_id,
                               Category.order(Arel.sql('LOWER(name)')),

--- a/app/views/modeles/show.html.erb
+++ b/app/views/modeles/show.html.erb
@@ -22,7 +22,27 @@
     <div class="col">
       <%= render CardComponent.new do |card| %>
         <dl class="show-page_dl d-grid row-gap-2 mb-0">
-          <% %i[name category architecture u manufacturer nb_elts color].each do |attribute_name| %>
+          <% card.with_header do %>
+            <%= t("show.cards.identification") %>
+          <% end %>
+
+          <% %i[name].each do |attribute_name| %>
+            <dt class="pb-2"><%= Modele.human_attribute_name(attribute_name) %></dt>
+            <dd class="mb-0 pb-2 ps-3"><%= @modele.public_send(attribute_name) %></dd>
+          <% end %>
+
+          <dt class="pb-2"><%= Modele.human_attribute_name(:network_types) %></dt>
+          <dd class="mb-0 pb-2 ps-3"><%= @modele.decorated.network_types_to_human %></dd>
+        </dl>
+      <% end %>
+
+      <%= render CardComponent.new(extra_classes: "mt-4") do |card| %>
+        <% card.with_header do %>
+          <%= t("show.cards.features") %>
+        <% end %>
+
+        <dl class="show-page_dl d-grid row-gap-2 mb-0">
+          <% %i[category architecture u manufacturer nb_elts color].each do |attribute_name| %>
             <dt class="pb-2"><%= Modele.human_attribute_name(attribute_name) %></dt>
             <dd class="mb-0 pb-2 ps-3"><%= @modele.public_send(attribute_name) %></dd>
           <% end %>
@@ -35,7 +55,7 @@
     <div class="col">
       <%= render CardComponent.new do |card| %>
         <% card.with_header do %>
-          <%= t(".preview") %>
+          <%= t("show.cards.preview") %>
         <% end %>
 
         <%= render partial: "visualization", locals: { modele: @modele } %>

--- a/app/views/port_types/_form.html.erb
+++ b/app/views/port_types/_form.html.erb
@@ -1,12 +1,22 @@
 <%= form_for(@port_type, html: { class: "col-12 col-md-10 col-lg-8 mx-auto", role: "form" }) do |f| %>
   <%= render FormErrorsComponent.new(@port_type) %>
   <%= render CardComponent.new(extra_classes: "bg-body-tertiary") do |card| %>
+    <% card.with_header do %>
+      <%= t("show.cards.identification") %>
+    <% end %>
+
     <fieldset class="col-12">
       <%= f.label :name, class: "form-label" %>
       <%= f.text_field :name, class: "form-control" %>
     </fieldset>
+  <% end %>
 
-    <div class="col-12 mt-4">
+  <%= render CardComponent.new(extra_classes: "bg-body-tertiary mt-4") do |card| %>
+    <% card.with_header do %>
+      <%= t("show.cards.features") %>
+    <% end %>
+
+    <div class="col-12">
       <fieldset class="form-check">
         <%= f.check_box :power, class: "form-check-input" %>
         <%= f.label :power, class: "form-check-label" %>

--- a/app/views/port_types/show.html.erb
+++ b/app/views/port_types/show.html.erb
@@ -8,19 +8,35 @@
 
 <%= render Page::HeadingShowComponent.new(resource: @port_type, title: @port_type.to_s, breadcrumb_steps:) %>
 <div class="col-12 p-4 border-top">
-  <div class="col-12 col-lg-6">
-    <%= render CardComponent.new do |card| %>
-      <dl class="show-page_dl d-grid row-gap-2 mb-0">
-        <% %i[name].each do |attribute_name| %>
-          <dt class="pb-2"><%= Architecture.human_attribute_name(attribute_name) %></dt>
-          <dd class="mb-0 pb-2 ps-3"><%= @port_type.public_send(attribute_name) %></dd>
+  <div class="row row-cols-1 row-cols-lg-2 row-gap-4">
+    <div class="col">
+      <%= render CardComponent.new do |card| %>
+        <% card.with_header do %>
+          <%= t("show.cards.identification") %>
         <% end %>
 
-        <% icon = @port_type.power ? "check" : "x" %>
-        <dt class="pb-2"><%= Architecture.human_attribute_name(:power) %></dt>
-        <dd class="mb-0 pb-2 ps-3"><span class="bi bi-<%= icon %>-square"></span></dd>
-      </dl>
-    <% end %>
+        <dl class="show-page_dl d-grid row-gap-2 mb-0">
+          <% %i[name].each do |attribute_name| %>
+            <dt class="pb-2"><%= Architecture.human_attribute_name(attribute_name) %></dt>
+            <dd class="mb-0 pb-2 ps-3"><%= @port_type.public_send(attribute_name) %></dd>
+          <% end %>
+        </dl>
+      <% end %>
+    </div>
+
+    <div class="col">
+      <%= render CardComponent.new do |card| %>
+        <% card.with_header do %>
+          <%= t("show.cards.features") %>
+        <% end %>
+
+        <dl class="show-page_dl d-grid row-gap-2 mb-0">
+          <% icon = @port_type.power ? "check" : "x" %>
+          <dt class="pb-2"><%= Architecture.human_attribute_name(:power) %></dt>
+          <dd class="mb-0 pb-2 ps-3"><span class="bi bi-<%= icon %>-square"></span></dd>
+        </dl>
+      <% end %>
+    </div>
   </div>
   <%= render ChangelogEntries::ObjectListComponent.new(@port_type) %>
 </div>

--- a/app/views/rooms/_form.html.erb
+++ b/app/views/rooms/_form.html.erb
@@ -1,6 +1,11 @@
 <%= form_for(@room, html: { class: "col-12 col-md-10 col-lg-8 mx-auto", role: "form" }) do |f| %>
   <%= render FormErrorsComponent.new(@room) %>
+
   <%= render CardComponent.new(extra_classes: "bg-body-tertiary") do |card| %>
+    <% card.with_header do %>
+      <%= t("show.cards.identification") %>
+    <% end %>
+
     <fieldset class="col-12">
       <%= f.label :name, class: "form-label" %>
       <%= f.text_field :name, class: "form-control" %>
@@ -10,8 +15,14 @@
       <%= f.label :description, class: "form-label" %>
       <%= f.text_area :description, class: "form-control" %>
     </fieldset>
+  <% end %>
 
-    <fieldset class="col-12 mt-4">
+  <%= render CardComponent.new(extra_classes: "bg-body-tertiary mt-4") do |card| %>
+    <% card.with_header do %>
+      <%= t("show.cards.features") %>
+    <% end %>
+
+    <fieldset class="col-12">
       <%= f.label :surface_area, class: "form-label" %>
       <div class="input-group">
         <%= f.number_field :surface_area, class: "form-control" %>
@@ -40,7 +51,7 @@
 
   <%= render CardComponent.new(extra_classes: "bg-body-tertiary mt-4") do |card| %>
     <% card.with_header do %>
-      <%= t("display") %>
+      <%= t("show.cards.display") %>
     <% end %>
 
     <fieldset class="col-12">

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -24,12 +24,24 @@
   <div class="row row-cols-1 row-cols-lg-2 row-gap-4">
     <div class="col">
       <%= render CardComponent.new do |card| %>
+        <% card.with_header do %>
+          <%= t("show.cards.identification") %>
+        <% end %>
+
         <dl class="show-page_dl d-grid row-gap-2 mb-0">
           <% %i[name description].each do |attribute_name| %>
             <dt class="pb-2"><%= Room.human_attribute_name(attribute_name) %></dt>
             <dd class="mb-0 pb-2 ps-3"><%= @room.public_send(attribute_name) %></dd>
           <% end %>
+        </dl>
+      <% end %>
 
+      <%= render CardComponent.new(extra_classes: "mt-4") do |card| %>
+        <% card.with_header do %>
+          <%= t("show.cards.features") %>
+        <% end %>
+
+        <dl class="show-page_dl d-grid row-gap-2 mb-0">
           <dt class="pb-2"><%= Room.human_attribute_name(:surface_area) %></dt>
           <dd class="mb-0 pb-2 ps-3">
             <%= surface_area_with_suffix(@room.surface_area) %>
@@ -37,30 +49,6 @@
 
           <dt class="pb-2"><%= Room.human_attribute_name(:access_control) %></dt>
           <dd class="mb-0 pb-2 ps-3"><%= @room.decorated.access_control_to_human %></dd>
-        </dl>
-      <% end %>
-
-      <!-- Card shown on lg, in 2nd position (Grid isn't working as Masonry) -->
-      <%= render CardComponent.new(extra_classes: "d-none d-lg-flex mt-4") do |card| %>
-        <% card.with_header do %>
-          <%= t("display") %>
-        <% end %>
-
-        <dl class="show-page_dl d-grid row-gap-2 mb-0">
-          <dt class="pb-2"><%= Room.human_attribute_name(:position) %></dt>
-          <dd class="mb-0 pb-2 ps-3"><%= @room.position %></dd>
-
-          <dt class="pb-2"><%= Room.human_attribute_name(:display_on_home_page) %></dt>
-          <dd class="mb-0 pb-2 ps-3">
-            <span><%= t("boolean.#{@room.display_on_home_page}") %></span>
-          </dd>
-
-          <dt class="pb-2"><%= Room.human_attribute_name(:status) %></dt>
-          <dd class="mb-0 pb-2 ps-3">
-            <span class="badge rounded-pill <%= @room.decorated.badge_color_for_status %>">
-              <%= Room.human_attribute_name("status.#{@room.status}") %>
-            </span>
-          </dd>
         </dl>
       <% end %>
     </div>
@@ -76,13 +64,10 @@
           <dd class="mb-0 pb-2 ps-3"><%= link_to @room.site, site_path(@room.site) %></dd>
         </dl>
       <% end %>
-    </div>
 
-    <!-- Card shown on mobile, in 3rd position (Grid isn't working as Masonry) -->
-    <div class="col d-lg-none">
-      <%= render CardComponent.new do |card| %>
+      <%= render CardComponent.new(extra_classes: "mt-4") do |card| %>
         <% card.with_header do %>
-          <%= t("display") %>
+          <%= t("show.cards.display") %>
         <% end %>
 
         <dl class="show-page_dl d-grid row-gap-2 mb-0">

--- a/app/views/servers/_form.html.erb
+++ b/app/views/servers/_form.html.erb
@@ -14,7 +14,7 @@
     </div>
   <% end %>
 
-  <%= render CardComponent.new(extra_classes: "bg-body-tertiary") do |card| %>
+  <%= render CardComponent.new(extra_classes: "mt-4 bg-body-tertiary") do |card| %>
     <% card.with_header do %>
       <%= Modele.model_name.human %>
     <% end %>
@@ -61,12 +61,12 @@
     <% end %>
 
     <div class="row g-3">
-      <fieldset class="col-md-6 col-12 mt-md-3 mt-4">
+      <fieldset class="col-md-6 col-12">
         <%= f.label :numero, class: "form-label" %>
         <%= f.text_field :numero, class: "form-control" %>
       </fieldset>
 
-      <fieldset class="col-md-6 col-12 mt-4">
+      <fieldset class="col-md-6 col-12 mt-md-3 mt-4">
         <%= f.label :server_state_id, class: "form-label" %>
         <%= f.collection_select(:server_state_id, ServerState.sorted, :id, :name, { prompt: false, include_blank: true },
                                                                                   { class: "form-select" }) %>
@@ -78,11 +78,56 @@
                                                                          { class: "form-select" }) %>
       </fieldset>
 
-      <fieldset class="col-12 mt-4 align-self-center">
+      <fieldset class="col-md-6 col-12 mt-4 align-self-end">
         <div class="form-check">
           <%= f.check_box :critique, class: "form-check-input" %>
           <%= f.label :critique, class: "form-check-label" %>
         </div>
+      </fieldset>
+
+      <fieldset class="col-md-6 col-12 mt-4">
+        <%= f.label :domaine_id, class: "form-label" %>
+        <%= f.collection_select(:domaine_id,
+                                Domaine.sorted,
+                                :id,
+                                :name,
+                                { prompt: true, include_blank: true },
+                                {
+                                  class: "form-select",
+                                  data: { controller: "select" },
+                                  placeholder: t("select.placeholder")
+                                })
+        %>
+      </fieldset>
+
+      <fieldset class="col-md-6 col-12 mt-4">
+        <%= f.label :cluster_id, class: "form-label" %>
+        <%= f.collection_select(:cluster_id,
+                                Cluster.sorted,
+                                :id,
+                                :name,
+                                { prompt: true, include_blank: true },
+                                {
+                                  class: "form-select",
+                                  data: { controller: "select" },
+                                  placeholder: t("select.placeholder")
+                                })
+        %>
+      </fieldset>
+
+      <fieldset class="col-md-6 col-12 mt-4">
+        <%= f.label :gestion_id, class: "form-label" %>
+        <%= f.collection_select(:gestion_id,
+                                Gestion.sorted,
+                                :id,
+                                :name,
+                                { prompt: true, include_blank: true },
+                                {
+                                  class: "form-select",
+                                  d‡ata: { controller: "select" },
+                                  placeholder: t("select.placeholder")
+                                })
+        %>
       </fieldset>
     </div>
   <% end %>

--- a/app/views/servers/_form.html.erb
+++ b/app/views/servers/_form.html.erb
@@ -3,6 +3,19 @@
 
   <%= render CardComponent.new(extra_classes: "bg-body-tertiary") do |card| %>
     <% card.with_header do %>
+      <%= t("show.cards.identification") %>
+    <% end %>
+
+    <div class="row g-3">
+      <fieldset class="col-12">
+        <%= f.label :name, class: "form-label" %>
+        <%= f.text_field :name, class: "form-control" %>
+      </fieldset>
+    </div>
+  <% end %>
+
+  <%= render CardComponent.new(extra_classes: "bg-body-tertiary") do |card| %>
+    <% card.with_header do %>
       <%= Modele.model_name.human %>
     <% end %>
 
@@ -42,13 +55,12 @@
     </div>
   <% end %>
 
-  <%= render CardComponent.new(extra_classes: "bg-body-tertiary mt-4") do |card| %>
-    <div class="row g-3">
-      <fieldset class="col-md-6 col-12">
-        <%= f.label :name, class: "form-label" %>
-        <%= f.text_field :name, class: "form-control" %>
-      </fieldset>
+  <%= render CardComponent.new(extra_classes: "mt-4 bg-body-tertiary") do |card| %>
+    <% card.with_header do %>
+      <%= t("show.cards.features") %>
+    <% end %>
 
+    <div class="row g-3">
       <fieldset class="col-md-6 col-12 mt-md-3 mt-4">
         <%= f.label :numero, class: "form-label" %>
         <%= f.text_field :numero, class: "form-control" %>

--- a/app/views/servers/_form.html.erb
+++ b/app/views/servers/_form.html.erb
@@ -84,51 +84,6 @@
           <%= f.label :critique, class: "form-check-label" %>
         </div>
       </fieldset>
-
-      <fieldset class="col-md-6 col-12 mt-4">
-        <%= f.label :domaine_id, class: "form-label" %>
-        <%= f.collection_select(:domaine_id,
-                                Domaine.sorted,
-                                :id,
-                                :name,
-                                { prompt: true, include_blank: true },
-                                {
-                                  class: "form-select",
-                                  data: { controller: "select" },
-                                  placeholder: t("select.placeholder")
-                                })
-        %>
-      </fieldset>
-
-      <fieldset class="col-md-6 col-12 mt-4">
-        <%= f.label :cluster_id, class: "form-label" %>
-        <%= f.collection_select(:cluster_id,
-                                Cluster.sorted,
-                                :id,
-                                :name,
-                                { prompt: true, include_blank: true },
-                                {
-                                  class: "form-select",
-                                  data: { controller: "select" },
-                                  placeholder: t("select.placeholder")
-                                })
-        %>
-      </fieldset>
-
-      <fieldset class="col-md-6 col-12 mt-4">
-        <%= f.label :gestion_id, class: "form-label" %>
-        <%= f.collection_select(:gestion_id,
-                                Gestion.sorted,
-                                :id,
-                                :name,
-                                { prompt: true, include_blank: true },
-                                {
-                                  class: "form-select",
-                                  d‡ata: { controller: "select" },
-                                  placeholder: t("select.placeholder")
-                                })
-        %>
-      </fieldset>
     </div>
   <% end %>
 

--- a/app/views/servers/show.html.erb
+++ b/app/views/servers/show.html.erb
@@ -97,7 +97,7 @@
           </dl>
         <% end %>
 
-        <%= render CardComponent.new do |card| %>
+        <%= render CardComponent.new(extra_classes: "mt-4") do |card| %>
           <% card.with_header do %>
             <%= Modele.model_name.human %>
           <% end %>

--- a/app/views/servers/show.html.erb
+++ b/app/views/servers/show.html.erb
@@ -88,6 +88,17 @@
       <div class="col">
         <%= render CardComponent.new do |card| %>
           <% card.with_header do %>
+            <%= t("show.cards.identification") %>
+          <% end %>
+
+          <dl class="show-page_dl d-grid row-gap-2 mb-0">
+            <dt class="pb-2"><%= Server.human_attribute_name(:name) %></dt>
+            <dd class="mb-0 pb-2 ps-3"><%= @server.name %></dd>
+          </dl>
+        <% end %>
+
+        <%= render CardComponent.new do |card| %>
+          <% card.with_header do %>
             <%= Modele.model_name.human %>
           <% end %>
 
@@ -127,6 +138,10 @@
         <% end %>
 
         <%= render CardComponent.new(extra_classes: "mt-4") do |card| %>
+          <% card.with_header do %>
+            <%= t("show.cards.features") %>
+          <% end %>
+
           <dl class="show-page_dl d-grid row-gap-2 mb-0">
             <dt class="pb-2"><%= Server.human_attribute_name(:numero) %></dt>
             <dd class="mb-0 pb-2 ps-3"><%= @server.try(:numero) %></dd>
@@ -182,16 +197,20 @@
           </dl>
         <% end %>
 
-        <% if @server.photo.attached? %>
+        <% if @server.documents.present? %>
           <!-- Card shown on lg, in 2nd position (Grid isn't working as Masonry) -->
           <%= render CardComponent.new(extra_classes: "mt-4 d-none d-lg-flex") do |card| %>
             <% card.with_header do %>
-              <%= Server.human_attribute_name(:photo) %>
+              <%= t(".attached_documents") %>
             <% end %>
-
-            <%= link_to @server.photo, rel: :noopener, target: :_blank do %>
-              <%= image_tag @server.photo.representation(resize_to_limit: [1200, 1200]), class: "w-100" %>
-            <% end %>
+            <ul>
+              <% @server.documents.each do |doc| %>
+                <%- next unless doc.document.present? %>
+                <li>
+                  <%= link_to(doc.document.metadata["filename"], doc.document_url, { target: :_blank })  %>
+                </li>
+              <% end %>
+            </ul>
           <% end %>
         <% end %>
       </div>
@@ -271,19 +290,6 @@
           </dl>
         <% end %>
 
-        <% if @server.photo.attached? %>
-          <!-- Card shown on mobile, in 3rd position (Grid isn't working as Masonry) -->
-          <%= render CardComponent.new(extra_classes: "d-lg-none mt-4") do |card| %>
-            <% card.with_header do %>
-              <%= Server.human_attribute_name(:photo) %>
-            <% end %>
-
-            <%= link_to @server.photo, rel: :noopener, target: :_blank do %>
-              <%= image_tag @server.photo.representation(resize_to_limit: [1200, 1200]), class: "w-100" %>
-            <% end %>
-          <% end %>
-        <% end %>
-
         <%= render CardComponent.new(extra_classes: "mt-4") do |card| %>
           <% card.with_header do %>
             <%= t(".glpi_data") %>
@@ -345,7 +351,8 @@
         <% end %>
 
         <% if @server.documents.present? %>
-          <%= render CardComponent.new(extra_classes: "mt-4") do |card| %>
+          <!-- Card shown on mobile, in 3rd position (Grid isn't working as Masonry) -->
+          <%= render CardComponent.new(extra_classes: "d-lg-none mt-4") do |card| %>
             <% card.with_header do %>
               <%= t(".attached_documents") %>
             <% end %>
@@ -357,6 +364,18 @@
                 </li>
               <% end %>
             </ul>
+          <% end %>
+        <% end %>
+
+        <% if @server.photo.attached? %>
+          <%= render CardComponent.new(extra_classes: "mt-4") do |card| %>
+            <% card.with_header do %>
+              <%= Server.human_attribute_name(:photo) %>
+            <% end %>
+
+            <%= link_to @server.photo, rel: :noopener, target: :_blank do %>
+              <%= image_tag @server.photo.representation(resize_to_limit: [1200, 1200]), class: "w-100" %>
+            <% end %>
           <% end %>
         <% end %>
       </div>

--- a/app/views/sites/_form.html.erb
+++ b/app/views/sites/_form.html.erb
@@ -1,6 +1,10 @@
 <%= form_for(@site, html: { class: "col-12 col-md-10 col-lg-8 mx-auto", role: "form" }) do |f| %>
   <%= render FormErrorsComponent.new(@site) %>
   <%= render CardComponent.new(extra_classes: "bg-body-tertiary") do |card| %>
+    <% card.with_header do %>
+      <%= t("show.cards.identification") %>
+    <% end %>
+
     <fieldset class="col-12">
       <%= f.label :name, class: "form-label" %>
       <%= f.text_field :name, class: "form-control" %>
@@ -69,7 +73,7 @@
 
   <%= render CardComponent.new(extra_classes: "mt-4 bg-body-tertiary") do |card| %>
     <% card.with_header do %>
-      <%= t("display") %>
+      <%= t("show.cards.display") %>
     <% end %>
 
     <fieldset class="col-12">

--- a/app/views/sites/show.html.erb
+++ b/app/views/sites/show.html.erb
@@ -8,6 +8,10 @@
   <div class="row row-cols-1 row-cols-lg-2 row-gap-4">
     <div class="col">
       <%= render CardComponent.new do |card| %>
+        <% card.with_header do %>
+          <%= t("show.cards.identification") %>
+        <% end %>
+
         <dl class="show-page_dl d-grid row-gap-2 mb-0">
           <% %i[name description].each do |attribute_name| %>
             <dt class="pb-2"><%= Site.human_attribute_name(attribute_name) %></dt>
@@ -19,7 +23,7 @@
       <!-- Cards shown on lg, in 2nd and 3rd position (Grid isn't working as Masonry) -->
       <%= render CardComponent.new(extra_classes: "d-none d-lg-flex mt-4") do |card| %>
         <% card.with_header do %>
-          <%= t("display") %>
+          <%= t("show.cards.display") %>
         <% end %>
 
         <dl class="show-page_dl d-grid row-gap-2 mb-0">
@@ -91,7 +95,7 @@
     <div class="col d-lg-none">
       <%= render CardComponent.new(extra_classes: "d-lg-none") do |card| %>
         <% card.with_header do %>
-          <%= t("display") %>
+          <%= t("show.cards.display") %>
         <% end %>
 
         <dl class="show-page_dl d-grid row-gap-2 mb-0">

--- a/app/views/stacks/_form.html.erb
+++ b/app/views/stacks/_form.html.erb
@@ -1,11 +1,22 @@
 <%= form_for(@stack, html: { class: "col-12 col-md-10 col-lg-8 mx-auto", role: "form" }) do |f| %>
   <%= render FormErrorsComponent.new(@stack) %>
   <%= render CardComponent.new(extra_classes: "bg-body-tertiary") do |card| %>
+    <% card.with_header do %>
+      <%= t("show.cards.identification") %>
+    <% end %>
+
     <fieldset class="col-12">
       <%= f.label :name, class: "form-label" %>
       <%= f.text_field :name, class: "form-control" %>
     </fieldset>
-    <fieldset class="col-12 mt-4">
+  <% end %>
+
+  <%= render CardComponent.new(extra_classes: "bg-body-tertiary mt-4") do |card| %>
+    <% card.with_header do %>
+      <%= t("show.cards.features") %>
+    <% end %>
+
+    <fieldset class="col-12">
       <%= f.label :color, class: "form-label" %>
       <%= f.text_field :color, class: "form-control" %>
     </fieldset>

--- a/app/views/stacks/show.html.erb
+++ b/app/views/stacks/show.html.erb
@@ -8,15 +8,35 @@
 
 <%= render Page::HeadingShowComponent.new(resource: @stack, title: @stack.name, breadcrumb_steps:) %>
 <div class="col-12 p-4 border-top">
-  <div class="col-12 col-lg-6">
-    <%= render CardComponent.new do |card| %>
-      <dl class="show-page_dl d-grid row-gap-2 mb-0">
-        <% %i[name color].each do |attribute_name| %>
-          <dt class="pb-2"><%= Stack.human_attribute_name(attribute_name) %></dt>
-          <dd class="mb-0 pb-2 ps-3"><%= @stack.public_send(attribute_name) %></dd>
+  <div class="row row-cols-1 row-cols-lg-2 row-gap-4">
+    <div class="col">
+      <%= render CardComponent.new do |card| %>
+        <% card.with_header do %>
+          <%= t("show.cards.identification") %>
         <% end %>
-      </dl>
-    <% end %>
+
+        <dl class="show-page_dl d-grid row-gap-2 mb-0">
+          <% %i[name].each do |attribute_name| %>
+            <dt class="pb-2"><%= Stack.human_attribute_name(attribute_name) %></dt>
+            <dd class="mb-0 pb-2 ps-3"><%= @stack.public_send(attribute_name) %></dd>
+          <% end %>
+        </dl>
+      <% end %>
+    </div>
+    <div class="col">
+      <%= render CardComponent.new do |card| %>
+        <% card.with_header do %>
+          <%= t("show.cards.features") %>
+        <% end %>
+
+        <dl class="show-page_dl d-grid row-gap-2 mb-0">
+          <% %i[color].each do |attribute_name| %>
+            <dt class="pb-2"><%= Stack.human_attribute_name(attribute_name) %></dt>
+            <dd class="mb-0 pb-2 ps-3"><%= @stack.public_send(attribute_name) %></dd>
+          <% end %>
+        </dl>
+      <% end %>
+    </div>
   </div>
   <%= render HasManyTurboFrameComponent.new(
     Server.model_name.human.pluralize,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,12 +11,30 @@ en:
   cables:
     index:
       title: Connections
+
+  devise:
+    passwords:
+      new:
+        help_text: We'll send password reset instructions.
+      edit:
+        title: Change your password
+
   rooms:
     action_buttons:
       caption:
         ports: Ports
         unreferenced_client: The corresponding port on the twin card is wired
         no_client: The corresponding port on the twin card is not wired
+
+  select:
+    placeholder: Type to filter...
+
+  show:
+    cards:
+      display: Display
+      features: Features
+      identification: Identification
+
   users:
     my_account:
       title: My account
@@ -28,13 +46,3 @@ en:
         flashes:
           updated: Your preferences have been updated
     logout: Log out
-
-  devise:
-    passwords:
-      new:
-        help_text: We'll send password reset instructions.
-      edit:
-        title: Change your password
-
-  select:
-    placeholder: Type to filter...

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,6 +34,7 @@ en:
       display: Display
       features: Features
       identification: Identification
+      preview: Preview
 
   users:
     my_account:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -45,6 +45,7 @@ fr:
       display: Affichage
       features: Caractéristiques
       identification: Identification
+      preview: Prévisualisation
     tabs:
       details: Détails
 
@@ -426,8 +427,6 @@ fr:
       title: Dupliquer le modèle %{modele_name}
     preview:
       modal_title: Prévisualisation du modèle %{modele_name}
-    show:
-      preview: Prévisualisation
   external_app_records:
     index:
       title: Synchronisation avec GLPI

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -41,6 +41,10 @@ fr:
       back_wiring: Cablage - Face arrière
     port_list: Liste des ports
   show:
+    cards:
+      display: Affichage
+      features: Caractéristiques
+      identification: Identification
     tabs:
       details: Détails
 
@@ -48,7 +52,6 @@ fr:
   inventories: Inventaires
   label_date: Date
   label_details: Détails
-  display: Affichage
 
   access_control:
     badge: Badge


### PR DESCRIPTION
Site, Room, Islet, Frame, Air_conditionner, Model, Server*, Bays** :

- création d'un bloc "identification" reprenant les champs "Nom" et "Description" quand il existe.
  - à décliner pour tous les modèles
- Tous les autres champs de l'actuel bloc par défaut sont regroupés dans un bloc "Caractéristiques".

*: server : ajouter le bloc, même si le nom est déjà repris dans la
représentation du serveur.

**: bays : ajouter le bloc, avec un nom généré, non modifiable en mode
édition ou création