### PR TITLE
Rubocop cleanup

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -96,25 +96,6 @@ Naming/PredicateName:
     - 'app/models/port_type.rb'
     - 'app/models/server.rb'
 
-# Offense count: 1
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: PreferredName.
-Naming/RescuedExceptionsVariableName:
-  Exclude:
-    - 'app/controllers/servers_grids_controller.rb'
-
-# Offense count: 1
-# Configuration parameters: MinSize.
-Performance/CollectionLiteralInLoop:
-  Exclude:
-    - 'lib/tasks/update_pdu_lines.rake'
-
-# Offense count: 1
-# This cop supports safe autocorrection (--autocorrect).
-Performance/CompareWithBlock:
-  Exclude:
-    - 'app/models/frame.rb'
-
 # Offense count: 2
 # This cop supports unsafe autocorrection (--autocorrect-all).
 Performance/Detect:
@@ -127,13 +108,6 @@ Performance/Detect:
 Performance/MapCompact:
   Exclude:
     - 'app/models/server.rb'
-
-# Offense count: 1
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: MaxKeyValuePairs.
-Performance/RedundantMerge:
-  Exclude:
-    - 'app/controllers/servers_controller.rb'
 
 # Offense count: 3
 # This cop supports safe autocorrection (--autocorrect).
@@ -252,14 +226,6 @@ Rails/DynamicFindBy:
     - 'db/migrate/20180110152701_add_attributes_to_servers.rb'
     - 'lib/tasks/update_pdu_lines.rake'
 
-# Offense count: 1
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: Include.
-# Include: app/models/**/*.rb
-Rails/EnumHash:
-  Exclude:
-    - 'app/models/user.rb'
-
 # Offense count: 4
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: EnforcedStyle.
@@ -319,13 +285,6 @@ Rails/InverseOf:
     - 'app/models/move.rb'
     - 'app/models/server.rb'
 
-# Offense count: 1
-# Configuration parameters: Include.
-# Include: app/controllers/**/*.rb, app/mailers/**/*.rb
-Rails/LexicallyScopedActionFilter:
-  Exclude:
-    - 'app/controllers/users/sessions_controller.rb'
-
 # Offense count: 19
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: Include.
@@ -361,12 +320,6 @@ Rails/RedundantActiveRecordAllMethod:
     - 'db/migrate/20170727132107_create_enclosures.rb'
     - 'db/migrate/20170803155630_init_cables_from_current_ports.rb'
     - 'db/migrate/20180110152701_add_attributes_to_servers.rb'
-
-# Offense count: 1
-# This cop supports safe autocorrection (--autocorrect).
-Rails/RedundantForeignKey:
-  Exclude:
-    - 'app/models/move.rb'
 
 # Offense count: 6
 # This cop supports safe autocorrection (--autocorrect).
@@ -430,20 +383,8 @@ Rails/WhereNot:
     - 'app/models/server.rb'
     - 'lib/tasks/update_pdu_lines.rake'
 
-# Offense count: 1
-# Configuration parameters: Severity.
-Rails/WhereNotWithMultipleConditions:
-  Exclude:
-    - 'app/controllers/connections_controller.rb'
-
 # Offense count: 2
 Rake/ClassDefinitionInTask:
-  Exclude:
-    - 'lib/tasks/convert_activities_to_changelog_entries.rake'
-
-# Offense count: 1
-# This cop supports safe autocorrection (--autocorrect).
-Rake/Desc:
   Exclude:
     - 'lib/tasks/convert_activities_to_changelog_entries.rake'
 
@@ -477,24 +418,10 @@ Style/ConditionalAssignment:
 Style/Documentation:
   Enabled: false
 
-# Offense count: 1
-# This cop supports safe autocorrection (--autocorrect).
-Style/EmptyLambdaParameter:
-  Exclude:
-    - 'app/models/card.rb'
-
 # Offense count: 37
 # This cop supports safe autocorrection (--autocorrect).
 Style/ExpandPathArguments:
   Enabled: false
-
-# Offense count: 1
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: format, sprintf, percent
-Style/FormatString:
-  Exclude:
-    - 'app/helpers/modeles_helper.rb'
 
 # Offense count: 3
 # This cop supports safe autocorrection (--autocorrect).
@@ -585,20 +512,6 @@ Style/IfUnlessModifier:
     - 'app/services/import_equipment_by_csv.rb'
     - 'db/migrate/20221220143609_add_foreign_key_constraint_to_active_storage_attachments_for_blob_id.active_storage.rb'
 
-# Offense count: 1
-# This cop supports safe autocorrection (--autocorrect).
-Style/KeywordParametersOrder:
-  Exclude:
-    - 'spec/support/shared_examples/models/changelogable.rb'
-
-# Offense count: 1
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: line_count_dependent, lambda, literal
-Style/Lambda:
-  Exclude:
-    - 'test/services/omniauth_dynamic_full_host_test.rb'
-
 # Offense count: 5
 # This cop supports safe autocorrection (--autocorrect).
 Style/MultilineIfModifier:
@@ -622,12 +535,6 @@ Style/MutableConstant:
     - 'app/models/memory_type.rb'
     - 'app/models/pdu.rb'
     - 'app/models/server.rb'
-
-# Offense count: 1
-# This cop supports safe autocorrection (--autocorrect).
-Style/NestedTernaryOperator:
-  Exclude:
-    - 'app/helpers/servers_helper.rb'
 
 # Offense count: 9
 # This cop supports safe autocorrection (--autocorrect).
@@ -660,19 +567,6 @@ Style/NumericPredicate:
     - 'app/controllers/ports_controller.rb'
     - 'app/helpers/servers_helper.rb'
 
-# Offense count: 1
-# This cop supports safe autocorrection (--autocorrect).
-Style/OrAssignment:
-  Exclude:
-    - 'app/controllers/servers_controller.rb'
-
-# Offense count: 1
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: AllowSafeAssignment, AllowInMultilineConditions.
-Style/ParenthesesAroundCondition:
-  Exclude:
-    - 'app/services/import_equipment_by_csv.rb'
-
 # Offense count: 2
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: PreferredDelimiters.
@@ -680,36 +574,6 @@ Style/PercentLiteralDelimiters:
   Exclude:
     - 'app/controllers/servers_grids_controller.rb'
     - 'app/helpers/servers_helper.rb'
-
-# Offense count: 1
-# This cop supports safe autocorrection (--autocorrect).
-Style/Proc:
-  Exclude:
-    - 'lib/omniauth/dynamic_full_host.rb'
-
-# Offense count: 1
-# This cop supports safe autocorrection (--autocorrect).
-Style/RedundantBegin:
-  Exclude:
-    - 'app/services/import_equipment_by_csv.rb'
-
-# Offense count: 1
-# This cop supports safe autocorrection (--autocorrect).
-Style/RedundantCapitalW:
-  Exclude:
-    - 'app/controllers/servers_grids_controller.rb'
-
-# Offense count: 1
-# This cop supports safe autocorrection (--autocorrect).
-Style/RedundantCondition:
-  Exclude:
-    - 'app/helpers/servers_helper.rb'
-
-# Offense count: 1
-# This cop supports safe autocorrection (--autocorrect).
-Style/RedundantConstantBase:
-  Exclude:
-    - 'config/environments/production.rb'
 
 # Offense count: 13
 # This cop supports safe autocorrection (--autocorrect).
@@ -770,14 +634,6 @@ Style/RescueStandardError:
   Exclude:
     - 'app/controllers/servers_grids_controller.rb'
     - 'lib/tasks/convert_activities_to_changelog_entries.rake'
-
-# Offense count: 1
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: ConvertCodeThatCanStartToReturnNil, AllowedMethods, MaxChainLength.
-# AllowedMethods: present?, blank?, presence, try, try!
-Style/SafeNavigation:
-  Exclude:
-    - 'app/models/server.rb'
 
 # Offense count: 2
 # This cop supports safe autocorrection (--autocorrect).

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -364,7 +364,7 @@ GEM
     orm_adapter (0.5.0)
     pagy (9.3.3)
     parallel (1.26.3)
-    parser (3.3.7.0)
+    parser (3.3.7.1)
       ast (~> 2.4.1)
       racc
     passenger (6.0.24)
@@ -486,14 +486,14 @@ GEM
       rspec-support (~> 3.13)
     rspec-support (3.13.2)
     rubanok (0.5.1)
-    rubocop (1.71.0)
+    rubocop (1.71.2)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 2.9.3, < 3.0)
-      rubocop-ast (>= 1.36.2, < 2.0)
+      rubocop-ast (>= 1.38.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
     rubocop-ast (1.38.0)
@@ -810,7 +810,7 @@ CHECKSUMS
   orm_adapter (0.5.0) sha256=aa5d0be5d540cbb46d3a93e88061f4ece6a25f6e97d6a47122beb84fe595e9b9
   pagy (9.3.3) sha256=4831418eb4ec7cc5658ea57de559cc3a960286db36f98d4c1c65e19db0e2bb60
   parallel (1.26.3) sha256=d86babb7a2b814be9f4b81587bf0b6ce2da7d45969fab24d8ae4bf2bb4d4c7ef
-  parser (3.3.7.0) sha256=7449011771e3e7881297859b849de26a6f4fccd515bece9520a87e7d2116119b
+  parser (3.3.7.1) sha256=7dbe61618025519024ac72402a6677ead02099587a5538e84371b76659e6aca1
   passenger (6.0.24) sha256=acd635c0aa850af364eb3caec02d367c37e37676288d82a90650d9827413714c
   pg (1.5.9) sha256=761efbdf73b66516f0c26fcbe6515dc7500c3f0aa1a1b853feae245433c64fdc
   popper_js (2.11.8) sha256=f4b0be717fc0d50bdb3dbbc55788525a9e0e8f640b76c9971fc34ee609eadbd2
@@ -854,7 +854,7 @@ CHECKSUMS
   rspec-rails (7.1.0) sha256=94585b69c4086ca79afae5cc8d2c5e314f6ad32a88c927f9c065b99596e3ee47
   rspec-support (3.13.2) sha256=cea3a2463fd9b84b9dcc9685efd80ea701aa8f7b3decb3b3ce795ed67737dbec
   rubanok (0.5.1) sha256=4c496d0fe2510c47a084c556018bfd95d388e7553b741ec9138b7139c801f3ec
-  rubocop (1.71.0) sha256=e19679efd447346ac476122313d3788ae23c38214790bcf660e984c747608bf0
+  rubocop (1.71.2) sha256=9a7b7501aac661a338ed7ff2a5eba78e581759e1f0d3c82362b2ca217ed3f97f
   rubocop-ast (1.38.0) sha256=4fdf6792fe443a9a18acb12dbc8225d0d64cd1654e41fedb30e79c18edbb26ae
   rubocop-capybara (2.21.0) sha256=5d264efdd8b6c7081a3d4889decf1451a1cfaaec204d81534e236bc825b280ab
   rubocop-performance (1.23.1) sha256=f22f86a795f5e6a6180aac2c6fc172534b173a068d6ed3396d6460523e051b82

--- a/app/controllers/connections_controller.rb
+++ b/app/controllers/connections_controller.rb
@@ -35,11 +35,14 @@ class ConnectionsController < ApplicationController
     @to_port = @cable.connections.reject { |conn| conn.port_id.to_i == @from_port.id }.first.try(:port) if @cable.present?
 
     # Destination server
-    if @from_port.is_power_input?
-      @to_server = @to_port.present? ? @to_port.server : @frame.pdus.first
+    if @to_port.present?
+      @to_server = @to_port.server
+    elsif @from_port.is_power_input?
+      @to_server = @frame.pdus.first
     else
-      @to_server = @to_port.present? ? @to_port.server : @frame.servers.where.not(position: nil, modele_id: nil).order(:position).first
+      @to_server = @frame.servers.where("position NOT NULL AND modele_id NOT NULL").order(:position).first
     end
+
     if @to_server
       @to_server.create_missing_ports
       @to_server.reload

--- a/app/controllers/servers_controller.rb
+++ b/app/controllers/servers_controller.rb
@@ -40,7 +40,7 @@ class ServersController < ApplicationController
       if positions[index].present?
         server = Server.find_by_id(id)
         new_params = { position: positions[index] }
-        new_params.merge!({ frame_id: frame.id }) if frame.present?
+        new_params[:frame_id] = frame.id if frame.present?
 
         server.update(new_params)
       end
@@ -127,8 +127,7 @@ class ServersController < ApplicationController
 
   # Use callbacks to share common setup or constraints between actions.
   def set_server
-    @server = Server.where('lower(numero) = ?', params[:id].to_s.downcase).includes(:cards => [:ports => %i[connection cable], :card_type => [:port_type]]).first
-    @server = Server.friendly.find(params[:id].to_s.downcase) unless @server
+    @server = Server.friendly_find_by_numero_or_name(params[:id])
   end
 
   # Never trust parameters from the scary internet, only allow the white list through.

--- a/app/controllers/servers_grids_controller.rb
+++ b/app/controllers/servers_grids_controller.rb
@@ -20,9 +20,9 @@ class ServersGridsController < ApplicationController
 
         begin
           @servers = ServersGrid.new(@merged_params[:servers_grid])
-        rescue => ex
+        rescue => e
           @servers = ServersGrid.new(params[:servers_grid])
-          logger.error ex.message
+          logger.error e.message
         end
       end
       format.csv do

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -2,6 +2,6 @@
 
 module Users
   class SessionsController < Devise::SessionsController
-    skip_before_action :verify_authenticity_token, :only => :create
+    skip_before_action :verify_authenticity_token, only: :create # rubocop:disable Rails/LexicallyScopedActionFilter
   end
 end

--- a/app/helpers/modeles_helper.rb
+++ b/app/helpers/modeles_helper.rb
@@ -2,13 +2,12 @@
 
 module ModelesHelper
   def lighten_color(hex_color, amount = 0.6)
-    if hex_color
-      hex_color = hex_color.gsub('#', '')
-      rgb = hex_color.scan(/../).map { |color| color.hex }
-      rgb[0] = [(rgb[0].to_i + (255 * amount)).round, 255].min
-      rgb[1] = [(rgb[1].to_i + (255 * amount)).round, 255].min
-      rgb[2] = [(rgb[2].to_i + (255 * amount)).round, 255].min
-      "#%02x%02x%02x" % rgb
-    end
+    hex_color = hex_color.gsub('#', '')
+    rgb = hex_color.scan(/../).map { |color| color.hex }
+    rgb[0] = [(rgb[0].to_i + (255 * amount)).round, 255].min
+    rgb[1] = [(rgb[1].to_i + (255 * amount)).round, 255].min
+    rgb[2] = [(rgb[2].to_i + (255 * amount)).round, 255].min
+
+    format("#%02x%02x%02x", *rgb)
   end
 end

--- a/app/helpers/servers_helper.rb
+++ b/app/helpers/servers_helper.rb
@@ -14,8 +14,10 @@ module ServersHelper # rubocop:disable Metrics/ModuleLength
       else
         cards_names.join('-')
       end
+    elsif component.name.present?
+      "#{component.name.include?('SL') ? component.name[2] : component.name}"
     else
-      component.name.present? ? "#{component.name.include?('SL') ? component.name[2] : component.name}" : component.position
+      component.position
     end
   end
 
@@ -141,7 +143,7 @@ module ServersHelper # rubocop:disable Metrics/ModuleLength
     end
 
     link_to label.to_s, edit_port_url, id: port_id, title: (port_data.present? ? "#{port_data.vlans}" : ""),
-                                       class: "border border-secondary port port#{port_class} #{port_data.try(:cable_color) ? port_data.try(:cable_color) : "empty"}",
+                                       class: "border border-secondary port port#{port_class} #{port_data.try(:cable_color) || "empty"}",
                                        data: { url: edit_port_url, position:, type:, controller: 'tooltip', bs_placement: 'top' }, target: :_top
   end
 

--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -20,7 +20,7 @@ class Card < ApplicationRecord
 
   after_commit :set_twin_card
 
-  scope :on_patch_panels, -> () { joins(:server => { :modele => :category }).where("categories.name = 'Patch Panel'") }
+  scope :on_patch_panels, -> { joins(:server => { :modele => :category }).where("categories.name = 'Patch Panel'") }
 
   def to_s
     "Carte #{server} / #{card_type} / #{composant}"

--- a/app/models/frame.rb
+++ b/app/models/frame.rb
@@ -37,7 +37,7 @@ class Frame < ApplicationRecord
   end
 
   def self.all_sorted
-    Frame.includes(:islet => :room, :bay => :islet).sort { |f1, f2| f1.name_with_room_and_islet <=> f2.name_with_room_and_islet }
+    Frame.includes(:islet => :room, :bay => :islet).sort_by(&:name_with_room_and_islet)
   end
 
   def should_generate_new_friendly_id?

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -5,7 +5,7 @@ class Move < ApplicationRecord
 
   belongs_to :moveable, polymorphic: true
   belongs_to :frame
-  belongs_to :prev_frame, class_name: 'Frame', foreign_key: :prev_frame_id
+  belongs_to :prev_frame, class_name: "Frame"
 
   attr_accessor :remove_connections
 

--- a/app/models/server.rb
+++ b/app/models/server.rb
@@ -76,6 +76,12 @@ class Server < ApplicationRecord
     )
   }
 
+  def self.friendly_find_by_numero_or_name(name)
+    name = name.to_s.downcase
+
+    Server.find_by('lower(numero) = ?', name) || Server.friendly.find(name)
+  end
+
   def to_s
     name.to_s
   end
@@ -113,7 +119,7 @@ class Server < ApplicationRecord
   def connected_servers_ids_through_twin_cards_with_color
     connections = directly_connected_servers_ids_with_color
     connected_ports.each do |port|
-      if port.card && port.card.twin_card_id
+      if port.card&.twin_card_id
         twin_card = Card.find(port.card.twin_card_id)
         twin_card_port = twin_card.ports.includes(:connection).where(position: port.position).first
         if twin_card_port

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,7 @@ class User < ApplicationRecord
   AVAILABLE_BAY_BACKGROUND_COLORS = %w[modele gestion cluster].freeze
   AVAILABLE_BAY_ORIENTATIONS = %w[front back].freeze
 
-  enum :role, %i[user vip admin]
+  enum :role, { user: 0, vip: 1, admin: 2 }
 
   acts_as_token_authenticatable
   has_changelog except: %i[sign_in_count current_sign_in_at last_sign_in_at current_sign_in_ip last_sign_in_ip]

--- a/app/processors/concerns/sortable.rb
+++ b/app/processors/concerns/sortable.rb
@@ -10,9 +10,9 @@ module Sortable
   end
 
   class_methods do
-    def sortable(fields:, orders: SORT_ORDERS, &block)
+    def sortable(fields:, orders: SORT_ORDERS, &)
       match :sort_by, :sort do
-        instance_eval(&block) if block_given?
+        instance_eval(&) if block_given?
 
         default do |sort_by:, sort: "asc"|
           raise "Possible injection: #{sort}" unless orders.include?(sort.to_s)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -52,7 +52,7 @@ Rails.application.configure do
   # Log to STDOUT with the current request id as a default log tag.
   config.log_tags = [:request_id]
   config.logger = ActiveSupport::Logger.new("log/production.log")
-    .tap  { |logger| logger.formatter = ::Logger::Formatter.new }
+    .tap  { |logger| logger.formatter = Logger::Formatter.new }
     .then { |logger| ActiveSupport::TaggedLogging.new(logger) }
 
   # Change to "debug" to log everything (including potentially personally-identifiable information!)

--- a/lib/omniauth/dynamic_full_host.rb
+++ b/lib/omniauth/dynamic_full_host.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # configures public url for our application
-OmniAuth.config.full_host = Proc.new do |env|
+OmniAuth.config.full_host = proc do |env|
   url = env["rack.session"]["omniauth.origin"] || env["omniauth.origin"]
   # if no url found, fall back to config secrets
   if url.blank?

--- a/lib/tasks/convert_activities_to_changelog_entries.rake
+++ b/lib/tasks/convert_activities_to_changelog_entries.rake
@@ -2,6 +2,7 @@
 
 require "benchmark"
 
+desc "Convert Activities to ChangelogEntries"
 task convert_activities_to_changelog_entries: :environment do
   # Backport old Rails code to make PublicActivity parameters export works
   module ActiveRecord # rubocop:disable Lint/ConstantDefinitionInBlock

--- a/lib/tasks/update_pdu_lines.rake
+++ b/lib/tasks/update_pdu_lines.rake
@@ -45,7 +45,7 @@ namespace :update_pdu_lines do
     puts "ERROR: #{card_type}" unless card_type.valid?
 
     frames.each do |frame|
-      %w[A B].each do |line_name|
+      %w[A B].each do |line_name| # rubocop:disable Performance/CollectionLiteralInLoop
         pdu_name = "PDU_#{frame}_#{line_name}"
         pdu = Server.find_by(frame: frame,
                              name: pdu_name)

--- a/spec/models/server_spec.rb
+++ b/spec/models/server_spec.rb
@@ -43,6 +43,20 @@ RSpec.describe Server do
     it { is_expected.to validate_uniqueness_of(:numero) }
   end
 
+  describe ".friendly_find_by_numero_or_name" do
+    context "with id" do
+      it { expect(described_class.friendly_find_by_numero_or_name(1)).to eq(servers(:one)) }
+    end
+
+    context "with numero" do
+      it { expect(described_class.friendly_find_by_numero_or_name("ABCDEFG32")).to eq(servers(:two)) }
+    end
+
+    context "with slug" do
+      it { expect(described_class.friendly_find_by_numero_or_name("server-name-4")).to eq(servers(:four)) }
+    end
+  end
+
   describe "#validate_numero_cannot_be_a_current_server_name" do
     before { servers(:one).save }
 

--- a/spec/support/shared_examples/models/changelogable.rb
+++ b/spec/support/shared_examples/models/changelogable.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-shared_examples_for "changelogable" do |object: nil, new_attributes:|
+shared_examples_for "changelogable" do |new_attributes:, object: nil|
   let(:new_object) do
     if object.is_a?(Proc)
       instance_exec(&object)

--- a/test/fixtures/servers.yml
+++ b/test/fixtures/servers.yml
@@ -74,7 +74,8 @@ with_cluster:
 four:
   id: 4
   frame_id: 4
-  name: ServerName3
+  slug: server-name-4
+  name: ServerName4
   modele_id: 1
   numero: CZ31535FEZ
   critique: false

--- a/test/services/omniauth_dynamic_full_host_test.rb
+++ b/test/services/omniauth_dynamic_full_host_test.rb
@@ -13,7 +13,7 @@ class DynamicFullHostTest < ActiveSupport::TestCase
   end
 
   def setup
-    app = lambda { |_env| [404, {}, ['Awesome']] }
+    app = ->(_env) { [404, {}, ['Awesome']] }
     @strategy = ExampleStrategy.new(app, {})
   end
 


### PR DESCRIPTION
Fix following rules (all rules with only 1 offense):
- `Naming/RescuedExceptionsVariableName`
- `Performance/CollectionLiteralInLoop`
- `Performance/CompareWithBlock`
- `Performance/RedundantMerge`
- `Rails/EnumHash`
- `Rails/LexicallyScopedActionFilter`
- `Rails/RedundantForeignKey`
- `Rails/WhereNotWithMultipleConditions`
- `Rake/Desc`
- `Style/EmptyLambdaParameter`
- `Style/FormatString`
- `Style/KeywordParametersOrder`
- `Style/Lambda`
- `Style/NestedTernaryOperator`
- `Style/OrAssignment`
- `Style/ParenthesesAroundCondition`
- `Style/Proc`
- `Style/RedundantBegin`
- `Style/RedundantCapitalW`
- `Style/RedundantCondition`
- `Style/RedundantConstantBase`
- `Style/SafeNavigation`