### PR TITLE
372744 - Add port position under RJ ports

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -945,6 +945,16 @@ body {
     }
   }
 
+  .very-specific-design {
+    .server-component {
+      .port_container {
+        small {
+          font-size: 0.65em;
+        }
+      }
+    }
+  }
+
   /* Bootstrap clean */
   ul.list-group.nested-form-list {
     .list-group-item:last-of-type {
@@ -953,9 +963,10 @@ body {
     }
 
     .list-group-item:not(:first-child) {
-     	border-top-width: 0;
+      border-top-width: 0;
     }
   }
+
 
   /* Tom-Select */
   /* Fix for dark mode */

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -971,7 +971,6 @@ body {
     }
   }
 
-
   /* Tom-Select */
   /* Fix for dark mode */
   .ts-dropdown, .ts-control, .ts-control input {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -354,8 +354,13 @@ table.card_layout {
 .connection_form {
   .back_server {
     .selected {
-      padding: 2px 1px;
-      background-color: #ee3b3b;
+      transform: scale(1.2);
+      z-index: 10;
+
+      a {
+        outline-color: var(--bs-primary-border-subtle);
+        box-shadow: 0 0 6px 3px rgba(var(--bs-primary-rgb), 1.0);
+      }
     }
 
     .very-specific-design {
@@ -814,8 +819,13 @@ body {
 
   .moved_connection_form {
     .selected {
-      padding:2px 1px;
-      background-color: #ee3b3b;
+      transform: scale(1.2);
+      z-index: 10;
+
+      a {
+        outline-color: var(--bs-primary-border-subtle);
+        box-shadow: 0 0 6px 3px rgba(var(--bs-primary-rgb), 1.0);
+      }
     }
   }
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -949,7 +949,11 @@ body {
     .server-component {
       .port_container {
         small {
-          font-size: 0.65em;
+          font-size: 0.5em;
+        }
+
+        &.float-start {
+          margin-top: 1px;
         }
       }
     }

--- a/app/helpers/servers_helper.rb
+++ b/app/helpers/servers_helper.rb
@@ -77,7 +77,7 @@ module ServersHelper # rubocop:disable Metrics/ModuleLength
           )
           if %w[RJ XRJ].include?(type.to_s) && (2..10).cover?(card_type.port_quantity)
             html_content += content_tag(:small,
-                                        position,
+                                        (position - 1 + card.first_port_position),
                                         class: class_names("ms-1": is_vertical_card))
           end
 

--- a/app/helpers/servers_helper.rb
+++ b/app/helpers/servers_helper.rb
@@ -38,7 +38,7 @@ module ServersHelper # rubocop:disable Metrics/ModuleLength
 
           html += content_tag(:span,
                               link_to_port_without_label(position, port_data, card_type.port_type, card.id, port_id),
-                              class: "port_container d-flex")
+                              class: "port_container d-flex align-items-center")
 
           if (cell_index + 1) % number_of_columns_in_cell(card.orientation, ports_per_cell, card_type.max_aligned_ports) == 0 # Every XX ports do
             html += '</div><div class="d-flex">'
@@ -69,13 +69,27 @@ module ServersHelper # rubocop:disable Metrics/ModuleLength
           port_data = card.ports.detect { |p| p.position == position }
           port_id = port_data.try(:id)
           port_data = include_moved_connections(moved_connections, port_data, port_id) # Add moved connections if any
+          type = card_type.port_type
+          is_vertical_card = %w[td-lr dt-lr].include?(card.orientation)
+
+          html_content = link_to_port(
+            position, port_data, type, card.id, port_id, (position - 1 + card.first_port_position).to_s.rjust(2, "0")
+          )
+          if %w[RJ XRJ].include?(type.to_s) && (2..10).cover?(card_type.port_quantity)
+            html_content += content_tag(:small,
+                                        position,
+                                        class: class_names("ms-1": is_vertical_card))
+          end
 
           html += content_tag(:span,
-                              link_to_port(position, port_data, card_type.port_type, card.id, port_id, (position - 1 + card.first_port_position).to_s.rjust(2, "0")),
-                              class: "port_container d-flex
-                                      #{"no_client" if twin_card_used_ports && port_data && port_data.cable_name && twin_card_used_ports.exclude?(port_data.position)}
-                                      #{"unreferenced_client" if twin_card_used_ports && (port_data.blank? || port_data.cable_name.blank?) && twin_card_used_ports.include?(position)}
-                                      #{"selected" if selected_port.present? && port_id == selected_port.try(:id)}")
+                              html_content,
+                              class: class_names(
+                                "port_container d-flex align-items-center",
+                                no_client: twin_card_used_ports && port_data && port_data.cable_name && twin_card_used_ports.exclude?(port_data.position),
+                                unreferenced_client: twin_card_used_ports && (port_data.blank? || port_data.cable_name.blank?) && twin_card_used_ports.include?(position),
+                                selected: selected_port.present? && port_id == selected_port.try(:id),
+                                "flex-column": !is_vertical_card
+                              ))
 
           if (cell_index + 1) % number_of_columns_in_cell(card.orientation, ports_per_cell, card_type.max_aligned_ports) == 0 # Every XX ports do
             html += '</div><div class="d-flex">'
@@ -96,15 +110,28 @@ module ServersHelper # rubocop:disable Metrics/ModuleLength
     port_quantity.to_i.times do |index|
       port_data = ports_data.detect { |p| p.position == index + 1 }
       port_id = port_data.try(:id)
+      is_vertical_card = %w[td-lr dt-lr].include?(port_data&.card&.orientation)
       port_data = include_moved_connections(moved_connections, port_data, port_id) # Add moved connections if any
 
+      html_content = link_to_port(index + 1, port_data, port_type, card_id, port_id)
+
+      if %w[RJ XRJ].include?(port_type.to_s) && (2..10).cover?(port_quantity)
+        html_content += content_tag(:small,
+                                    index + 1,
+                                    class: class_names("ms-1": is_vertical_card))
+      end
+
       html += content_tag(:span,
-                          link_to_port(index + 1, port_data, port_type, card_id, port_id),
-                          class: "port_container float-start
-                                  #{"no_client" if twin_card_used_ports && port_data && port_data.cable_name && twin_card_used_ports.exclude?(port_data.position)}
-                          #{"unreferenced_client" if twin_card_used_ports && (port_data.blank? || port_data.cable_name.blank?) && twin_card_used_ports.include?(index + 1)}
-                          #{"selected" if selected_port.present? && port_id == selected_port.try(:id)}")
+                          html_content,
+                          class: class_names(
+                            "port_container float-start d-flex align-items-center",
+                            no_client: twin_card_used_ports && port_data && port_data.cable_name && twin_card_used_ports.exclude?(port_data.position),
+                            unreferenced_client: twin_card_used_ports && (port_data.blank? || port_data.cable_name.blank?) && twin_card_used_ports.include?(index + 1),
+                            selected: selected_port.present? && port_id == selected_port.try(:id),
+                            "flex-column": !is_vertical_card
+                          ))
     end
+
     html.html_safe
   end
 
@@ -139,15 +166,20 @@ module ServersHelper # rubocop:disable Metrics/ModuleLength
 
   def link_to_port_by_type(label, type, port_data, position, card_id, port_id)
     edit_port_url = port_id ? connections_edit_path(from_port_id: port_id) : edit_port_path(id: 0, card_id: card_id, position: position)
+
     if %w[RJ XRJ FC ALIM].include? type
       port_class = type
     else
       port_class = "SCSI"
     end
 
-    link_to label.to_s, edit_port_url, id: port_id, title: (port_data.present? ? port_data.vlans.to_s : ""),
-                                       class: "border border-secondary port port#{port_class} #{port_data.try(:cable_color) || "empty"}",
-                                       data: { url: edit_port_url, position:, type:, controller: 'tooltip', bs_placement: 'top' }, target: :_top
+    link_to label.to_s,
+            edit_port_url,
+            id: port_id,
+            title: (port_data.present? ? port_data.vlans.to_s : ""),
+            class: "border border-secondary port port#{port_class} #{port_data.try(:cable_color) || "empty"}",
+            data: { url: edit_port_url, position:, type:, controller: 'tooltip', bs_placement: 'top' },
+            target: :_top
   end
 
   private

--- a/app/helpers/servers_helper.rb
+++ b/app/helpers/servers_helper.rb
@@ -77,7 +77,7 @@ module ServersHelper # rubocop:disable Metrics/ModuleLength
           )
           if %w[RJ XRJ].include?(type.to_s) && (2..10).cover?(card_type.port_quantity)
             html_content += content_tag(:small,
-                                        (position - 1 + card.first_port_position),
+                                        position - 1 + card.first_port_position,
                                         class: class_names("ms-1": is_vertical_card))
           end
 

--- a/app/views/servers/_draw_component.html.erb
+++ b/app/views/servers/_draw_component.html.erb
@@ -6,7 +6,7 @@
        connections.each { |c| twin_card_used_ports << c.port.position if c && c.port }
   end %>
 
-  <span class="server-component"
+  <span class="<%= class_names("server-component d-flex", "flex-column": (card.orientation == "td-lr" || card.orientation == "dt-lr")) %>"
         data-server-name="<%= server.name %>"
         data-server-id="<%= server.id %>"
         data-composant-id="<%= card.id %>"


### PR DESCRIPTION
- Add the port number beside RJ ports, when on a same card there is more than 1 and less than 10
- Display should be on the right of the port when the card is vertical, and under the port when horizontal