### PR TITLE
367812 - Fix 'User selects columns to display on Index'

### DIFF
--- a/app/controllers/concerns/columns_preferences.rb
+++ b/app/controllers/concerns/columns_preferences.rb
@@ -14,7 +14,7 @@ module ColumnsPreferences
       before_action(only:) do
         if params[:reset]
           session[key] = nil
-          redirect_back fallback_location: root_path
+          redirect_to URI.parse(request.referer || root_path).path
         elsif params[:save]
           session[key] = params[:columns]
         end

--- a/app/controllers/servers_controller.rb
+++ b/app/controllers/servers_controller.rb
@@ -5,7 +5,7 @@ class ServersController < ApplicationController
   include ColumnsPreferences
 
   DEFAULT_COLUMNS = %w[name numero modele.category_id islet_id bay_id network_types position].freeze
-  AVAILABLE_COLUMNS = %w[name numero modele.category_id islet_id bay_id network_types gestion_id frame_id cluster_id stack_id domaine_id position slug side color comment critique].freeze
+  AVAILABLE_COLUMNS = %w[name numero modele.category_id islet_id bay_id network_types position gestion_id frame_id cluster_id stack_id domaine_id slug side color comment critique].freeze
 
   columns_preferences_with model: Server, default: DEFAULT_COLUMNS, available: AVAILABLE_COLUMNS
 

--- a/app/views/servers/index.html.erb
+++ b/app/views/servers/index.html.erb
@@ -179,6 +179,10 @@
           <%= server.decorated.network_types_to_human %>
         <% end %>
 
+        <% table.with_column(Server.human_attribute_name(:position), name: :position, sort_by: :position) do |server| %>
+          <%= server.position %>
+        <% end %>
+
         <% table.with_column(Gestion.model_name.human, name: :gestion_id) do |server| %>
           <%= link_to server.gestion, gestion_path(server.gestion), data: { turbo_frame: :_top } if server.gestion %>
         <% end %>
@@ -197,10 +201,6 @@
 
         <% table.with_column(Stack.model_name.human, name: :stack_id) do |server| %>
           <%= link_to server.stack, stack_path(server.stack), data: { turbo_frame: :_top } if server.stack %>
-        <% end %>
-
-        <% table.with_column(Server.human_attribute_name(:position), name: :position, sort_by: :position) do |server| %>
-          <%= server.position %>
         <% end %>
 
         <% table.with_column(Server.human_attribute_name(:slug), name: :slug, sort_by: :slug) do |server| %>


### PR DESCRIPTION
Related to https://github.com/nanego/my-dcim/pull/323

- "Reset" columns preferences does not work
- Move Server's `position` column after other defaults columns
