### PR TITLE
Show server & model names in back pdf export

### DIFF
--- a/app/views/servers/_cables_export_content.html.erb
+++ b/app/views/servers/_cables_export_content.html.erb
@@ -27,7 +27,7 @@
   </div>
 
   <div class="d-flex flex-column gap-5">
-    <%= render partial: "servers/draw_server_compact", locals: { server: server } %>
+    <%= render partial: "servers/draw_server_compact", locals: { server: server, should_hide_left_block: true } %>
 
     <% unless server.cables.empty? %>
       <%= render List::DataTableComponent.new(server.cables) do |table| %>

--- a/app/views/servers/_draw_server_compact.html.erb
+++ b/app/views/servers/_draw_server_compact.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (server:, selected_port: nil, should_hide_left_block: request.format.pdf?) -%>
+<%# locals: (server:, selected_port: nil, should_hide_left_block: false) -%>
 
 <%= render partial: "servers/visualization", locals: { server:, selected_port: } %>
 
@@ -9,7 +9,7 @@
                   server_path(server, view: params[:view]),
                   { class: "server_name", data: { controller: "tooltip", bs_placement: "top" }, title: server.numero } %>
     </span>
-    <span>
+    <span class="d-print-none">
       <%= link_to draw_connections_path(server_id: server.id),
                   class: "draw_connections_link",
                   id: "draw_connections_link_#{server.id}",


### PR DESCRIPTION
With previous changes, on pdf exports of servers back view, server and model names were missing

**Changelog**
- Updating `app/views/servers/_draw_server_compact.html.erb` to not hide left block on PDF request.
- Updating `app/views/servers/_cables_export_content.html.erb` to add parameter to hde left block