### PR TITLE
style: correct herb actionview-no-silent-helper

### DIFF
--- a/app/views/architectures/index.html.erb
+++ b/app/views/architectures/index.html.erb
@@ -2,7 +2,7 @@
 
 <%= render Page::HeadingComponent.new(title:, breadcrumb:) do |heading| %>
   <% heading.with_right_content do %>
-    <% render ButtonComponent.new(
+    <%= render ButtonComponent.new(
       t(".new_architecture"),
       url: new_architecture_path,
       variant: :success,

--- a/app/views/bays/index.html.erb
+++ b/app/views/bays/index.html.erb
@@ -2,7 +2,7 @@
 
 <%= render Page::HeadingComponent.new(title:, breadcrumb:) do |heading| %>
   <% heading.with_right_content do %>
-    <% render ButtonComponent.new(
+    <%= render ButtonComponent.new(
       t(".new_bay"),
       url: new_bay_path,
       variant: :success,

--- a/app/views/bays/show.html.erb
+++ b/app/views/bays/show.html.erb
@@ -15,7 +15,7 @@
     ) do |heading| %>
   <% if @bay.frames.any? %>
     <% heading.with_extra_buttons do %>
-      <% if allowed_to?(:show?, @bay, with: Visualization::BayPolicy)
+      <%= if allowed_to?(:show?, @bay, with: Visualization::BayPolicy)
            render ButtonComponent.new(
              t("visualization.title"),
              url: visualization_bay_path(@bay),

--- a/app/views/card_types/index.html.erb
+++ b/app/views/card_types/index.html.erb
@@ -2,7 +2,7 @@
 
 <%= render Page::HeadingComponent.new(title:, breadcrumb:) do |heading| %>
   <% heading.with_right_content do %>
-    <% render ButtonComponent.new(
+    <%= render ButtonComponent.new(
       t(".new_card_type"),
       url: new_card_type_path,
       variant: :success,

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -1,7 +1,7 @@
 <% breadcrumb.add_step(title = Category.model_name.human.pluralize) %>
 <%= render Page::HeadingComponent.new(title:, breadcrumb:) do |heading| %>
   <% heading.with_right_content do %>
-    <% if allowed_to?(:create?)
+    <%= if allowed_to?(:create?)
          render ButtonComponent.new(
            t(".new_category"),
            url: new_category_path,

--- a/app/views/clusters/index.html.erb
+++ b/app/views/clusters/index.html.erb
@@ -2,7 +2,7 @@
 
 <%= render Page::HeadingComponent.new(title:, breadcrumb:) do |heading| %>
   <% heading.with_right_content do %>
-    <% render ButtonComponent.new(
+    <%= render ButtonComponent.new(
       t(".new_cluster"),
       url: new_cluster_path,
       variant: :success,

--- a/app/views/connections/edit.html.erb
+++ b/app/views/connections/edit.html.erb
@@ -11,7 +11,7 @@
 ) do |heading| %>
   <% heading.with_right_content do %>
     <% if @cable %>
-      <% render ButtonComponent.new(
+      <%= render ButtonComponent.new(
         t("action.delete"),
         url: cable_path(id: @cable.id),
         variant: :danger,

--- a/app/views/contact_roles/index.html.erb
+++ b/app/views/contact_roles/index.html.erb
@@ -2,7 +2,7 @@
 
 <%= render Page::HeadingComponent.new(title:, breadcrumb:) do |heading| %>
   <% heading.with_right_content do %>
-    <% render ButtonComponent.new(
+    <%= render ButtonComponent.new(
       t(".new_contact_role"),
       url: new_contact_role_path,
       variant: :success,

--- a/app/views/contacts/index.html.erb
+++ b/app/views/contacts/index.html.erb
@@ -2,7 +2,7 @@
 
 <%= render Page::HeadingComponent.new(title:, breadcrumb:) do |heading| %>
   <% heading.with_right_content do %>
-    <% render ButtonComponent.new(
+    <%= render ButtonComponent.new(
       t(".new_contact"),
       url: new_contact_path,
       variant: :success,

--- a/app/views/domains/index.html.erb
+++ b/app/views/domains/index.html.erb
@@ -2,7 +2,7 @@
 
 <%= render Page::HeadingComponent.new(title:, breadcrumb:) do |heading| %>
   <% heading.with_right_content do %>
-    <% render ButtonComponent.new(
+    <%= render ButtonComponent.new(
       t(".new_domain"),
       url: new_domain_path,
       variant: :success,

--- a/app/views/frames/index.html.erb
+++ b/app/views/frames/index.html.erb
@@ -2,7 +2,7 @@
 
 <%= render Page::HeadingComponent.new(title:, breadcrumb:) do |heading| %>
   <% heading.with_right_content do %>
-    <% render ButtonComponent.new(
+    <%= render ButtonComponent.new(
       t(".new_frame"),
       url: new_frame_path,
       variant: :success,

--- a/app/views/frames/show.html.erb
+++ b/app/views/frames/show.html.erb
@@ -7,7 +7,7 @@
       editable: allowed_to?(:update?, @frame),
     ) do |heading| %>
   <% heading.with_extra_buttons do %>
-    <% if allowed_to?(:show?, @frame, with: Visualization::FramePolicy)
+    <%= if allowed_to?(:show?, @frame, with: Visualization::FramePolicy)
          render ButtonComponent.new(
            t("visualization.title"),
            url: visualization_frame_path(@frame),

--- a/app/views/islets/index.html.erb
+++ b/app/views/islets/index.html.erb
@@ -2,7 +2,7 @@
 
 <%= render Page::HeadingComponent.new(title:, breadcrumb:) do |heading| %>
   <% heading.with_right_content do %>
-    <% render ButtonComponent.new(
+    <%= render ButtonComponent.new(
       t(".new_islet"),
       url: new_islet_path,
       variant: :success,

--- a/app/views/islets/show.html.erb
+++ b/app/views/islets/show.html.erb
@@ -7,7 +7,7 @@
       editable: allowed_to?(:update?, @islet),
     ) do |heading| %>
   <% heading.with_extra_buttons do %>
-    <% if allowed_to?(:show?, @islet, with: Visualization::IsletPolicy)
+    <%= if allowed_to?(:show?, @islet, with: Visualization::IsletPolicy)
          render ButtonComponent.new(
            t("visualization.title"),
            url: visualization_room_path(@islet.room, islet: @islet.name),

--- a/app/views/managers/index.html.erb
+++ b/app/views/managers/index.html.erb
@@ -2,7 +2,7 @@
 
 <%= render Page::HeadingComponent.new(title:, breadcrumb:) do |heading| %>
   <% heading.with_right_content do %>
-    <% render ButtonComponent.new(
+    <%= render ButtonComponent.new(
       t(".new_manager"),
       url: new_manager_path,
       variant: :success,

--- a/app/views/manufacturers/index.html.erb
+++ b/app/views/manufacturers/index.html.erb
@@ -2,7 +2,7 @@
 
 <%= render Page::HeadingComponent.new(title:, breadcrumb:) do |heading| %>
   <% heading.with_right_content do %>
-    <% if allowed_to?(:create?)
+    <%= if allowed_to?(:create?)
          render ButtonComponent.new(
            t(".new_manufacturer"),
            url: new_manufacturer_path,

--- a/app/views/modeles/index.html.erb
+++ b/app/views/modeles/index.html.erb
@@ -2,7 +2,7 @@
 
 <%= render Page::HeadingComponent.new(title:, breadcrumb:) do |heading| %>
   <% heading.with_right_content do %>
-    <% render ButtonComponent.new(
+    <%= render ButtonComponent.new(
       t(".new_modele"),
       url: new_modele_path,
       variant: :success,

--- a/app/views/modeles/show.html.erb
+++ b/app/views/modeles/show.html.erb
@@ -7,7 +7,7 @@
       editable: allowed_to?(:update?, @modele),
     ) do |heading| %>
   <% heading.with_extra_buttons do %>
-    <% if allowed_to?(:duplicate?, @modele)
+    <%= if allowed_to?(:duplicate?, @modele)
          render ButtonComponent.new(
            t("action.duplicate"),
            url: duplicate_modele_path(@modele),

--- a/app/views/moves_projects/index.html.erb
+++ b/app/views/moves_projects/index.html.erb
@@ -4,7 +4,7 @@
 
 <%= render Page::HeadingComponent.new(title:, breadcrumb:) do |heading| %>
   <% heading.with_right_content do %>
-    <% render ButtonComponent.new(t(".new_moves_project"),
+    <%= render ButtonComponent.new(t(".new_moves_project"),
                                   url: new_moves_project_path,
                                   variant: :success,
                                   icon: "plus-lg",

--- a/app/views/permission_scopes/index.html.erb
+++ b/app/views/permission_scopes/index.html.erb
@@ -2,7 +2,7 @@
 
 <%= render Page::HeadingComponent.new(title:, breadcrumb:) do |heading| %>
   <% heading.with_right_content do %>
-    <% render ButtonComponent.new(t(".new_permission_scope"),
+    <%= render ButtonComponent.new(t(".new_permission_scope"),
                                   url: new_permission_scope_path,
                                   variant: :success,
                                   icon: "plus-lg",

--- a/app/views/port_types/index.html.erb
+++ b/app/views/port_types/index.html.erb
@@ -2,7 +2,7 @@
 
 <%= render Page::HeadingComponent.new(title:, breadcrumb:) do |heading| %>
   <% heading.with_right_content do %>
-    <% render ButtonComponent.new(
+    <%= render ButtonComponent.new(
       t(".new_port_type"),
       url: new_port_type_path,
       variant: :success,

--- a/app/views/rooms/index.html.erb
+++ b/app/views/rooms/index.html.erb
@@ -2,7 +2,7 @@
 
 <%= render Page::HeadingComponent.new(title: title, breadcrumb:) do |heading| %>
   <% heading.with_right_content do %>
-    <% render ButtonComponent.new(
+    <%= render ButtonComponent.new(
       t(".new_room"),
       url: new_room_path,
       variant: :success,

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -7,7 +7,7 @@
       editable: allowed_to?(:update?, @room),
     ) do |heading| %>
   <% heading.with_extra_buttons do %>
-   <% if allowed_to?(:show?, @room, with: Visualization::RoomPolicy)
+   <%= if allowed_to?(:show?, @room, with: Visualization::RoomPolicy)
         render ButtonComponent.new(
           t("visualization.title"),
           url: visualization_room_path(@room),

--- a/app/views/servers_grids/index.html.erb
+++ b/app/views/servers_grids/index.html.erb
@@ -4,7 +4,7 @@
 
 <%= render Page::HeadingComponent.new(title:, breadcrumb:) do |heading| %>
   <% heading.with_right_content do %>
-    <% render ButtonComponent.new(t("export_button.exports.csv"),
+    <%= render ButtonComponent.new(t("export_button.exports.csv"),
                                   url: url_for(format: :csv, params: @merged_params || {}),
                                   variant: :outline_primary,
                                   icon: "filetype-csv",

--- a/app/views/sites/index.html.erb
+++ b/app/views/sites/index.html.erb
@@ -2,7 +2,7 @@
 
 <%= render Page::HeadingComponent.new(title: t(".title"), breadcrumb:) do |heading| %>
   <% heading.with_right_content do %>
-    <% render ButtonComponent.new(
+    <%= render ButtonComponent.new(
       t(".new_site"),
       url: new_site_path,
       variant: :success,

--- a/app/views/stacks/index.html.erb
+++ b/app/views/stacks/index.html.erb
@@ -2,7 +2,7 @@
 
 <%= render Page::HeadingComponent.new(title:, breadcrumb:) do |heading| %>
   <% heading.with_right_content do %>
-    <% render ButtonComponent.new(
+    <%= render ButtonComponent.new(
       t(".new_stack"),
       url: new_stack_path,
       variant: :success,

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -2,7 +2,7 @@
 
 <%= render Page::HeadingComponent.new(title:, breadcrumb:) do |heading| %>
   <% heading.with_right_content do %>
-    <% render ButtonComponent.new(t(".new_user"),
+    <%= render ButtonComponent.new(t(".new_user"),
                                   url: new_user_path,
                                   variant: :success,
                                   icon: "plus-lg",


### PR DESCRIPTION
> Avoid using `<% %>` with `render`. Use `<%= %>` to ensure the helper's output is rendered. (Herb Linter  actionview-no-silent-helper)