### PR TITLE
451141 - refactor: group CardType by PortType on Server form

### DIFF
--- a/app/decorators/card_type_decorator.rb
+++ b/app/decorators/card_type_decorator.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class CardTypeDecorator < ApplicationDecorator
+  class << self
+    include ActionView::Helpers::FormOptionsHelper
+
+    def grouped_by_port_type_options_for_select
+      grouped_card_types = CardType.includes(:port_type)
+        .sorted
+        .group_by(&:port_type)
+        .map do |port_type, card_types|
+          [port_type.to_s, card_types.map { |card_type| [card_type.to_s, card_type.id] }]
+      end
+
+      grouped_options_for_select(grouped_card_types)
+    end
+  end
+end

--- a/app/views/servers/_card_fields.html.erb
+++ b/app/views/servers/_card_fields.html.erb
@@ -34,8 +34,7 @@
         <span class="col-12 mt-2 col-sm-4 col-xl-3 ">
           <%= f.label Enclosure.human_attribute_name(:card_type_id), class: "form-label col-form-label-sm p-0" %>
           <%= f.select :card_type_id,
-                       options_for_select(CardType.sorted.map { |card_type| [card_type.name, card_type.id] },
-                                          f.object.card_type_id),
+                       CardTypeDecorator.grouped_by_port_type_options_for_select,
                        {},
                        { class: "form-select",
                          data: {

--- a/spec/decorators/card_type_decorator_spec.rb
+++ b/spec/decorators/card_type_decorator_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CardTypeDecorator, type: :decorator do
+  let(:card_type) { card_types(:one) }
+  let(:decorated_card_type) { card_type.decorated }
+
+  describe ".grouped_by_port_type_options_for_select" do
+    it do
+      expect(described_class.grouped_by_port_type_options_for_select)
+        .to have_tag("optgroup", with: { label: "FC" }) do
+          with_tag("option", with: { value: "3" }, text: "Card3")
+        end
+    end
+
+    it do
+      expect(described_class.grouped_by_port_type_options_for_select)
+        .to have_tag("optgroup", with: { label: "RJ" }) do
+          with_tag("option", with: { value: "2" }, text: "Card2")
+        end
+    end
+
+    it do # rubocop:disable RSpec/ExampleLength
+      expect(described_class.grouped_by_port_type_options_for_select)
+        .to have_tag("optgroup", with: { label: "IPMI" }) do
+          with_tag("option", with: { value: "1" }, text: "Card1")
+          with_tag("option", with: { value: "4" }, text: "6ALIM")
+          with_tag("option", with: { value: "5" }, text: "Card5")
+        end
+    end
+  end
+end


### PR DESCRIPTION
```rb
CardType.find_each.map do |type|
  [type.name, Server.where(id: Card.select(:server_id).where(card_type: type)).pluck(:name)]
end.to_h
```

To get the list of used `CardType` with servers related.