### PR TITLE
i18n: rework decorator locale keys and calls

### DIFF
--- a/app/decorators/bay_decorator.rb
+++ b/app/decorators/bay_decorator.rb
@@ -37,10 +37,10 @@ class BayDecorator < ApplicationDecorator
   def no_frame_warning_icon
     tag.span class: "bay-with-no-frame-warning ms-2" do
       concat(tag.span(class: "bi bi-exclamation-triangle-fill text-warning",
-                      title: I18n.t(".bays.decorator.no_frame_warning_text"),
+                      title: I18n.t("bay_decorator.no_frame_warning_text"),
                       aria: { hidden: true },
                       data: { controller: "tooltip", bs_placement: "right" }))
-      concat(tag.span(I18n.t(".bays.decorator.no_frame_warning_text"), class: "visually-hidden"))
+      concat(tag.span(I18n.t("bay_decorator.no_frame_warning_text"), class: "visually-hidden"))
     end
   end
 end

--- a/app/decorators/cable_decorator.rb
+++ b/app/decorators/cable_decorator.rb
@@ -24,7 +24,7 @@ class CableDecorator < ApplicationDecorator
 
     def colors_options_for_select
       Cable::COLORS.map do |k, v|
-        [I18n.t(".activerecord.attributes.cable/color.#{v}"), k]
+        [Cable.human_attribute_name("color.#{v}"), k]
       end
     end
   end

--- a/app/decorators/external_app_record_decorator.rb
+++ b/app/decorators/external_app_record_decorator.rb
@@ -4,14 +4,14 @@ class ExternalAppRecordDecorator < ApplicationDecorator
   class << self
     def external_serial_status_options_for_select
       ExternalAppRecord::EXTERNAL_SERIAL_STATUSES.map do |s|
-        [I18n.t(".activerecord.attributes.external_app_record.external_serials.#{s}"), s]
+        [ExternalAppRecord.human_attribute_name("external_serial.#{s}"), s]
       end
     end
   end
 
   def external_serial_to_badge_component
     status = external_serial.present? ? :found : :not_found
-    text = I18n.t(".activerecord.attributes.external_app_record.external_serials.#{status}").upcase
+    text = ExternalAppRecord.human_attribute_name("external_serial.#{status}").upcase
     color = status == :found ? :success : :danger
 
     BadgeComponent.new(text, color:, variant: :pill)

--- a/app/decorators/modele_decorator.rb
+++ b/app/decorators/modele_decorator.rb
@@ -17,7 +17,7 @@ class ModeleDecorator < ApplicationDecorator
   end
 
   def displays_to_human
-    return tag.span(I18n.t(".modeles.decorator.no_enclosure"), class: "fst-italic fw-light text-body-secondary") unless enclosures.any?
+    return tag.span(I18n.t("modele_decorator.no_enclosure"), class: "fst-italic fw-light text-body-secondary") unless enclosures.any?
 
     enclosures.map do |enclosure|
       Enclosure.human_attribute_name("display.#{enclosure.display}")

--- a/app/decorators/move_decorator.rb
+++ b/app/decorators/move_decorator.rb
@@ -21,6 +21,6 @@ class MoveDecorator < ApplicationDecorator
   end
 
   def display_name
-    I18n.t("moves.decorator.display_name", moveable:)
+    I18n.t("move_decorator.display_name", moveable:)
   end
 end

--- a/app/decorators/moved_connection_decorator.rb
+++ b/app/decorators/moved_connection_decorator.rb
@@ -2,7 +2,7 @@
 
 class MovedConnectionDecorator < ApplicationDecorator
   def description
-    I18n.t("moved_connections.decorator.description",
+    I18n.t("moved_connection_decorator.description",
            port_from_server: port_from.server.decorated.full_name,
            port_from_id:,
            port_to_server: port_to&.server&.decorated&.full_name, # rubocop:disable Style/SafeNavigationChainLength

--- a/config/locales/activerecord.en.yml
+++ b/config/locales/activerecord.en.yml
@@ -114,9 +114,9 @@ en:
         frame_ids: Location
         id: ID
         server_id: I.T. equipment
-        external_serials:
-          found: Found
-          not_found: Not found in GLPI
+      external_app_record/external_serial:
+        found: Found
+        not_found: Not found in GLPI
       modele:
         category_id: Category
         category: Category

--- a/config/locales/activerecord.fr.yml
+++ b/config/locales/activerecord.fr.yml
@@ -439,9 +439,9 @@ fr:
         frame_ids: Emplacement
         id: ID
         server_id: Matériel I.T.
-        external_serials:
-          found: Trouvé
-          not_found: Non trouvé dans GLPI
+      external_app_record/external_serial:
+        found: Trouvé
+        not_found: Non trouvé dans GLPI
       contact:
         first_name: Prénom
         last_name: Nom

--- a/config/locales/decorators.en.yml
+++ b/config/locales/decorators.en.yml
@@ -1,0 +1,12 @@
+en:
+  bay_decorator:
+    no_frame_warning_text: Please enter a frame for this bay
+
+  modele_decorator:
+    no_enclosure: No Enclosure
+
+  move_decorator:
+    display_name: Move of %{moveable}
+
+  moved_connection_decorator:
+    description: "Connection between %{port_from_server} (port #%{port_from_id}) and %{port_to_server} (port #%{port_to_id}) => vlans: %{vlans} // cablename: %{cablename} // color: %{color}"

--- a/config/locales/decorators.fr.yml
+++ b/config/locales/decorators.fr.yml
@@ -1,0 +1,12 @@
+fr:
+  bay_decorator:
+    no_frame_warning_text: Veuillez renseigner un châssis à cette baie
+
+  modele_decorator:
+    no_enclosure: Aucune enclosure
+
+  move_decorator:
+    display_name: Déplacement de %{moveable}
+
+  moved_connection_decorator:
+    description: "Connexion entre %{port_from_server} (port #%{port_from_id}) et %{port_to_server} (port #%{port_to_id}) => vlans : %{vlans} // nom du câble : %{cablename} // couleur : %{color}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -122,8 +122,6 @@ en:
       title: Delete the bay
       flashes:
         destroyed: The bay has been removed.
-    decorator:
-      no_frame_warning_text: Please enter a frame for this bay
     empty: Empty bay
     add_new: Add a bay
 
@@ -319,16 +317,10 @@ en:
 
   modeles:
     add_new: Add a model
-    decorator:
-      no_enclosure: No Enclosure
     destroy:
       title: Delete the modele
     preview:
       modal_title: Model %{modele_name} preview
-
-  moved_connections:
-    decorator:
-      description: "Connection between %{port_from_server} (port #%{port_from_id}) and %{port_to_server} (port #%{port_to_id}) => vlans: %{vlans} // cablename: %{cablename} // color: %{color}"
 
   moves:
     index:
@@ -376,8 +368,6 @@ en:
         delete: Delete this connection
     flashes:
       archived: This project is archived
-    decorator:
-      display_name: Move of %{moveable}
 
   moves_projects:
     index:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -383,8 +383,6 @@ fr:
       title: Dupliquer le modèle %{modele_name}
     preview:
       modal_title: Prévisualisation du modèle %{modele_name}
-    decorator:
-      no_enclosure: Aucune enclosure
   external_app_records:
     index:
       title: Synchronisation avec GLPI
@@ -545,10 +543,6 @@ fr:
         destroyed: Frame a bien été supprimé.
     add_new: Ajouter un châssis
 
-  moved_connections:
-    decorator:
-      description: "Connexion entre %{port_from_server} (port #%{port_from_id}) et %{port_to_server} (port #%{port_to_id}) => vlans : %{vlans} // nom du câble : %{cablename} // couleur : %{color}"
-
   moves:
     index:
       planned_on: Planifié le
@@ -591,8 +585,6 @@ fr:
         delete: Supprimer cette connexion
     flashes:
       archived: Ce projet est archivé
-    decorator:
-      display_name: Déplacement de %{moveable}
 
   moves_projects:
     index:
@@ -820,8 +812,6 @@ fr:
       title: Supprimer la baie
       flashes:
         destroyed: La baie a bien été supprimée.
-    decorator:
-      no_frame_warning_text: Veuillez renseigner un châssis à cette baie
     empty: Baie vide
     add_new: Ajouter une baie
   cables:


### PR DESCRIPTION
- Move decorators locales in separate file as components, and use same key composition
- Correct missing `human_attribute_name` usage